### PR TITLE
fix(auth): harden sign-up error handling and trust Vercel host

### DIFF
--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -34,7 +34,15 @@ export default function SignUpPage() {
 
       if (!res.ok) {
         const data = await res.json().catch(() => ({}))
-        setError(data.error || 'Could not create your account. Please try again.')
+        // The API returns errors as either a string (`{ error: '...' }`) or an
+        // object (`{ error: { message, code } }`). Normalise to a string so we
+        // never hand React a non-renderable object (React error #31).
+        const message =
+          typeof data.error === 'string'
+            ? data.error
+            : data.error?.message ||
+              'Could not create your account. Please try again.'
+        setError(message)
         setIsLoading(false)
         return
       }

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -12,6 +12,9 @@ import type { NextAuthConfig } from 'next-auth';
  * listed here; provider logic that needs Node APIs stays in `auth.ts`.
  */
 export const authConfig = {
+  // Trust the deployment host. On Vercel this is usually inferred, but being
+  // explicit avoids `UntrustedHost` 500s behind the proxy / on custom domains.
+  trustHost: true,
   pages: {
     signIn: '/sign-in',
   },


### PR DESCRIPTION
- Normalize the register API error response to a string in the sign-up page so an object-shaped error ({ message, code }) no longer crashes React with minified error #31 (white screen on a failed sign-up).
- Add trustHost: true to the Auth.js config to avoid UntrustedHost 500s on /api/auth/* behind the Vercel proxy and on custom domains.

Note: the production 500 root cause is a missing AUTH_SECRET env var on Vercel (breaks /api/auth/session). This commit only hardens the surrounding code; the env var must still be set and redeployed.