### PR TITLE
fix: persist category parentId in admin API routes

### DIFF
--- a/app/api/admin/categories/[id]/route.ts
+++ b/app/api/admin/categories/[id]/route.ts
@@ -46,7 +46,14 @@ export async function PATCH(
     const admin = requireAdmin(r);
     if (admin) return admin;
     const { id } = await context.params;
-    const { name, slug, description, image, isActive } = await request.json();
+    const { name, slug, description, image, parentId, isActive } = await request.json();
+
+    if (parentId && parentId === id) {
+      return NextResponse.json(
+        { error: 'A category cannot be its own parent' },
+        { status: 400 }
+      );
+    }
 
     if (slug) {
       const existingCategory = await prisma.category.findFirst({
@@ -68,7 +75,13 @@ export async function PATCH(
         ...(slug && { slug }),
         ...(description !== undefined && { description }),
         ...(image !== undefined && { image }),
+        ...(parentId !== undefined && { parentId: parentId || null }),
         ...(isActive !== undefined && { isActive }),
+      },
+      include: {
+        parent: { select: { id: true, name: true } },
+        children: { select: { id: true, name: true } },
+        _count: { select: { products: true, children: true } },
       },
     });
 

--- a/app/api/admin/categories/route.ts
+++ b/app/api/admin/categories/route.ts
@@ -15,7 +15,9 @@ export async function GET() {
 
     const categories = await prisma.category.findMany({
       include: {
-        _count: { select: { products: true } },
+        parent: { select: { id: true, name: true } },
+        children: { select: { id: true, name: true } },
+        _count: { select: { products: true, children: true } },
       },
       orderBy: { name: 'asc' },
     });
@@ -33,7 +35,7 @@ export async function POST(request: Request) {
     const admin = requireAdmin(r);
     if (admin) return admin;
 
-    const { name, slug, description, image, isActive = true } = await request.json();
+    const { name, slug, description, image, parentId, isActive = true } = await request.json();
 
     if (!name || !slug) {
       return NextResponse.json({ error: 'Name and slug are required' }, { status: 400 });
@@ -48,7 +50,12 @@ export async function POST(request: Request) {
     }
 
     const category = await prisma.category.create({
-      data: { name, slug, description, image, isActive },
+      data: { name, slug, description, image, parentId: parentId || null, isActive },
+      include: {
+        parent: { select: { id: true, name: true } },
+        children: { select: { id: true, name: true } },
+        _count: { select: { products: true, children: true } },
+      },
     });
 
     return NextResponse.json(category, { status: 201 });

--- a/app/api/admin/categories/upload/route.ts
+++ b/app/api/admin/categories/upload/route.ts
@@ -74,7 +74,9 @@ export async function POST(request: Request) {
         isActive,
       },
       include: {
-        _count: { select: { products: true } },
+        parent: { select: { id: true, name: true } },
+        children: { select: { id: true, name: true } },
+        _count: { select: { products: true, children: true } },
       },
     });
 


### PR DESCRIPTION
The admin POST and PATCH category handlers were dropping parentId, so subcategories were saved with parentId=null and appeared under the Categories tab instead of Subcategories. POST now saves parentId, PATCH now updates it (with a self-parent guard), and GET plus all create/update responses now load parent/children relations for the tree view.