### PR TITLE
fix: show Fashion Assistant chat bubble only on home screen

### DIFF
--- a/components/chat/chat-bubble.tsx
+++ b/components/chat/chat-bubble.tsx
@@ -1,12 +1,17 @@
 'use client'
 
 import { useState } from 'react'
+import { usePathname } from 'next/navigation'
 import { MessageCircle, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { ChatWindow } from './chat-window'
 
 export function ChatBubble() {
+  const pathname = usePathname()
   const [isOpen, setIsOpen] = useState(false)
+
+  // The Fashion Assistant is only offered on the home screen.
+  if (pathname !== '/') return null
 
   return (
     <>


### PR DESCRIPTION
The chat popper is mounted globally via Providers, so it appeared on every page. Gate ChatBubble on the route with usePathname() and render nothing unless the pathname is '/', so the assistant only shows on the home screen.