### PR TITLE
feat: saree-themed sign-in/sign-up UI + category placeholder

### DIFF
--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -4,6 +4,14 @@ import { useState, Suspense } from 'react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { signIn } from 'next-auth/react'
+import { Mail, Lock } from 'lucide-react'
+import { AuthShell } from '@/components/auth/auth-shell'
+import {
+  TextField,
+  PasswordField,
+  SubmitButton,
+  ErrorBanner,
+} from '@/components/auth/auth-fields'
 
 function SignInForm() {
   const router = useRouter()
@@ -38,75 +46,78 @@ function SignInForm() {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="bg-white shadow-xl rounded-lg p-8 space-y-5">
-      {error && (
-        <div className="rounded-md bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
-          {error}
-        </div>
-      )}
+    <form onSubmit={handleSubmit} className="space-y-5">
+      {error && <ErrorBanner message={error} />}
+
+      <TextField
+        id="email"
+        label="Email address"
+        type="email"
+        icon={Mail}
+        autoComplete="email"
+        required
+        value={email}
+        onChange={setEmail}
+        placeholder="you@example.com"
+      />
 
       <div>
-        <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
-          Email address
-        </label>
-        <input
-          id="email"
-          type="email"
-          autoComplete="email"
-          required
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:border-red-600 focus:ring-red-600 focus:outline-none focus:ring-1"
-        />
-      </div>
-
-      <div>
-        <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
-          Password
-        </label>
-        <input
+        <PasswordField
           id="password"
-          type="password"
+          label="Password"
+          icon={Lock}
           autoComplete="current-password"
           required
           value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:border-red-600 focus:ring-red-600 focus:outline-none focus:ring-1"
+          onChange={setPassword}
+          placeholder="Enter your password"
         />
+        <div className="mt-2 text-right">
+          <Link
+            href="/sign-in"
+            className="text-xs font-medium text-marigold-700 transition-colors hover:text-maroon-700"
+          >
+            Forgot password?
+          </Link>
+        </div>
       </div>
 
-      <button
-        type="submit"
-        disabled={isLoading}
-        className="w-full bg-red-600 text-white py-2.5 rounded-md font-medium hover:bg-red-700 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
-      >
-        {isLoading ? 'Signing in…' : 'Sign in'}
-      </button>
+      <SubmitButton loading={isLoading} loadingLabel="Signing in…">
+        Sign in
+      </SubmitButton>
 
       {/* When Google OAuth is added later, a `signIn('google')` button goes here. */}
+
+      <p className="pt-1 text-center text-sm text-maroon-700/80">
+        New to Saakie?{' '}
+        <Link
+          href="/sign-up"
+          className="font-semibold text-maroon-700 underline-offset-2 hover:underline"
+        >
+          Create an account
+        </Link>
+      </p>
     </form>
   )
 }
 
 export default function SignInPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8">
-        <div className="text-center">
-          <h2 className="mt-6 text-3xl font-extrabold text-gray-900">
-            Sign in to your account
-          </h2>
-          <p className="mt-2 text-sm text-gray-600">
-            Or{' '}
-            <Link href="/sign-up" className="font-medium text-red-600 hover:text-red-500">
-              create a new account
-            </Link>
-          </p>
-        </div>
-        <Suspense fallback={<div className="bg-white shadow-xl rounded-lg p-8 text-center text-gray-500">Loading…</div>}>
-          <SignInForm />
-        </Suspense>
-      </div>
-    </div>
+    <AuthShell
+      eyebrow="Welcome back"
+      title="Sign in to your account"
+      subtitle="Step back into a world of timeless weaves and curated elegance."
+      panelQuote="Drape yourself in heritage — every weave tells a story."
+    >
+      <Suspense
+        fallback={
+          <div className="rounded-xl border border-maroon-100 bg-white/60 p-8 text-center text-sm text-maroon-500">
+            Loading…
+          </div>
+        }
+      >
+        <SignInForm />
+      </Suspense>
+    </AuthShell>
   )
 }

--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -4,6 +4,14 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { signIn } from 'next-auth/react'
+import { User, Mail, Lock } from 'lucide-react'
+import { AuthShell } from '@/components/auth/auth-shell'
+import {
+  TextField,
+  PasswordField,
+  SubmitButton,
+  ErrorBanner,
+} from '@/components/auth/auth-fields'
 
 export default function SignUpPage() {
   const router = useRouter()
@@ -63,85 +71,67 @@ export default function SignUpPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-md w-full space-y-8">
-        <div className="text-center">
-          <h2 className="mt-6 text-3xl font-extrabold text-gray-900">
-            Create your account
-          </h2>
-          <p className="mt-2 text-sm text-gray-600">
-            Or{' '}
-            <Link href="/sign-in" className="font-medium text-red-600 hover:text-red-500">
-              sign in to existing account
-            </Link>
-          </p>
-        </div>
+    <AuthShell
+      eyebrow="Join the family"
+      title="Create your account"
+      subtitle="Begin your journey through India's finest handpicked sarees."
+      panelQuote="From the loom to your wardrobe — join a legacy of artisans."
+    >
+      <form onSubmit={handleSubmit} className="space-y-5">
+        {error && <ErrorBanner message={error} />}
 
-        <form onSubmit={handleSubmit} className="bg-white shadow-xl rounded-lg p-8 space-y-5">
-          {error && (
-            <div className="rounded-md bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
-              {error}
-            </div>
-          )}
+        <TextField
+          id="name"
+          label="Full name"
+          icon={User}
+          autoComplete="name"
+          required
+          value={name}
+          onChange={setName}
+          placeholder="Your name"
+        />
 
-          <div>
-            <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-1">
-              Full name
-            </label>
-            <input
-              id="name"
-              type="text"
-              autoComplete="name"
-              required
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:border-red-600 focus:ring-red-600 focus:outline-none focus:ring-1"
-            />
-          </div>
+        <TextField
+          id="email"
+          label="Email address"
+          type="email"
+          icon={Mail}
+          autoComplete="email"
+          required
+          value={email}
+          onChange={setEmail}
+          placeholder="you@example.com"
+        />
 
-          <div>
-            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
-              Email address
-            </label>
-            <input
-              id="email"
-              type="email"
-              autoComplete="email"
-              required
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:border-red-600 focus:ring-red-600 focus:outline-none focus:ring-1"
-            />
-          </div>
+        <PasswordField
+          id="password"
+          label="Password"
+          icon={Lock}
+          autoComplete="new-password"
+          required
+          minLength={8}
+          value={password}
+          onChange={setPassword}
+          placeholder="Create a password"
+          hint="At least 8 characters."
+        />
 
-          <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
-              Password
-            </label>
-            <input
-              id="password"
-              type="password"
-              autoComplete="new-password"
-              required
-              minLength={8}
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:border-red-600 focus:ring-red-600 focus:outline-none focus:ring-1"
-            />
-            <p className="mt-1 text-xs text-gray-500">At least 8 characters.</p>
-          </div>
+        <SubmitButton loading={isLoading} loadingLabel="Creating account…">
+          Create account
+        </SubmitButton>
 
-          <button
-            type="submit"
-            disabled={isLoading}
-            className="w-full bg-red-600 text-white py-2.5 rounded-md font-medium hover:bg-red-700 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+        {/* When Google OAuth is added later, a `signIn('google')` button goes here. */}
+
+        <p className="pt-1 text-center text-sm text-maroon-700/80">
+          Already have an account?{' '}
+          <Link
+            href="/sign-in"
+            className="font-semibold text-maroon-700 underline-offset-2 hover:underline"
           >
-            {isLoading ? 'Creating account…' : 'Create account'}
-          </button>
-
-          {/* When Google OAuth is added later, a `signIn('google')` button goes here. */}
-        </form>
-      </div>
-    </div>
+            Sign in
+          </Link>
+        </p>
+      </form>
+    </AuthShell>
   )
 }

--- a/app/api/categories/[slug]/route.ts
+++ b/app/api/categories/[slug]/route.ts
@@ -62,7 +62,7 @@ export async function GET(
         id: child.id,
         name: child.name,
         slug: child.slug,
-        image: child.image || '/images/placeholder-category.jpg',
+        image: child.image || '/images/placeholder-category.svg',
         count: child._count.products,
       })),
       pagination: {

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -25,7 +25,7 @@ export async function GET() {
       id: category.id,
       name: category.name,
       slug: category.slug,
-      image: category.image || '/images/placeholder-category.jpg',
+      image: category.image || '/images/placeholder-category.svg',
       count: category._count.products,
     }));
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -759,3 +759,46 @@
   outline: 2px solid #9ca3af;
   outline-offset: 2px;
 }
+
+/* ──────────────────────────────────────────────────────────────────────────
+   Saree-themed auth screens (sign-in / sign-up)
+   Decorative-only styles. Everything is pure CSS/SVG — no image assets — so
+   the silk + zari look renders even where product imagery is missing.
+   ────────────────────────────────────────────────────────────────────────── */
+
+/* Slow diagonal gold sheen sweeping across the decorative silk panel. */
+@keyframes zariSheen {
+  0%   { transform: translateX(-120%) skewX(-12deg); }
+  100% { transform: translateX(220%)  skewX(-12deg); }
+}
+.animate-zari-sheen {
+  animation: zariSheen 7s ease-in-out infinite;
+}
+
+/* Very slow drift for the paisley/mandala motif layer — adds life without
+   distracting from the form. */
+@keyframes motifDrift {
+  0%, 100% { transform: translateY(0) rotate(0deg); }
+  50%      { transform: translateY(-14px) rotate(2deg); }
+}
+.animate-motif-drift {
+  animation: motifDrift 14s ease-in-out infinite;
+}
+
+/* Animated zari-gold gradient used for headings and the brand rule. */
+.text-zari-gradient {
+  background: linear-gradient(100deg, #9a7b13 0%, #e6c757 30%, #fff4cf 50%, #e6c757 70%, #9a7b13 100%);
+  background-size: 200% auto;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+
+/* Respect users who prefer reduced motion. */
+@media (prefers-reduced-motion: reduce) {
+  .animate-zari-sheen,
+  .animate-motif-drift {
+    animation: none;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,18 @@
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
+import { Inter, Playfair_Display } from 'next/font/google'
 import './globals.css'
 import { Providers } from '@/components/providers'
 
-const inter = Inter({ subsets: ['latin'] })
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter' })
+
+// Editorial serif used for headings — gives the storefront its premium,
+// saree-boutique feel. Exposed as a CSS variable so any component can opt in
+// via the `font-serif` utility (wired up in tailwind.config.js).
+const playfair = Playfair_Display({
+  subsets: ['latin'],
+  variable: '--font-playfair',
+  display: 'swap',
+})
 
 export const metadata: Metadata = {
   title: 'Saakie_byknk - Premium Fashion Online',
@@ -32,7 +41,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${inter.variable} ${playfair.variable}`}>
       <body className={inter.className}>
         <Providers>{children}</Providers>
       </body>

--- a/components/auth/auth-fields.tsx
+++ b/components/auth/auth-fields.tsx
@@ -1,0 +1,181 @@
+'use client'
+
+import { useState } from 'react'
+import { Eye, EyeOff, type LucideIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+/**
+ * Saree-themed form primitives shared by the sign-in and sign-up screens.
+ * Styling only — these are plain controlled inputs, so callers keep full
+ * ownership of state and the NextAuth submit logic.
+ */
+
+const baseInput =
+  'w-full rounded-xl border border-maroon-200 bg-white/70 py-3 pl-11 pr-4 text-[15px] text-maroon-900 placeholder:text-maroon-300 shadow-sm transition-all duration-200 focus:border-zari focus:bg-white focus:outline-none focus:ring-2 focus:ring-zari/30'
+
+interface TextFieldProps {
+  id: string
+  label: string
+  type?: string
+  icon: LucideIcon
+  value: string
+  onChange: (value: string) => void
+  autoComplete?: string
+  required?: boolean
+  placeholder?: string
+}
+
+export function TextField({
+  id,
+  label,
+  type = 'text',
+  icon: Icon,
+  value,
+  onChange,
+  autoComplete,
+  required,
+  placeholder,
+}: TextFieldProps) {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="mb-1.5 block text-sm font-medium text-maroon-800"
+      >
+        {label}
+      </label>
+      <div className="relative">
+        <Icon
+          className="pointer-events-none absolute left-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-maroon-400"
+          aria-hidden="true"
+        />
+        <input
+          id={id}
+          type={type}
+          autoComplete={autoComplete}
+          required={required}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          className={baseInput}
+        />
+      </div>
+    </div>
+  )
+}
+
+interface PasswordFieldProps {
+  id: string
+  label: string
+  icon: LucideIcon
+  value: string
+  onChange: (value: string) => void
+  autoComplete?: string
+  required?: boolean
+  minLength?: number
+  placeholder?: string
+  /** Optional helper text shown beneath the field. */
+  hint?: string
+}
+
+export function PasswordField({
+  id,
+  label,
+  icon: Icon,
+  value,
+  onChange,
+  autoComplete,
+  required,
+  minLength,
+  placeholder,
+  hint,
+}: PasswordFieldProps) {
+  const [visible, setVisible] = useState(false)
+
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="mb-1.5 block text-sm font-medium text-maroon-800"
+      >
+        {label}
+      </label>
+      <div className="relative">
+        <Icon
+          className="pointer-events-none absolute left-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-maroon-400"
+          aria-hidden="true"
+        />
+        <input
+          id={id}
+          type={visible ? 'text' : 'password'}
+          autoComplete={autoComplete}
+          required={required}
+          minLength={minLength}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          className={cn(baseInput, 'pr-11')}
+        />
+        <button
+          type="button"
+          onClick={() => setVisible((v) => !v)}
+          aria-label={visible ? 'Hide password' : 'Show password'}
+          aria-pressed={visible}
+          className="absolute right-2 top-1/2 -translate-y-1/2 rounded-lg p-1.5 text-maroon-400 transition-colors hover:bg-maroon-50 hover:text-maroon-700 focus:outline-none focus:ring-2 focus:ring-zari/40"
+        >
+          {visible ? (
+            <EyeOff className="h-5 w-5" aria-hidden="true" />
+          ) : (
+            <Eye className="h-5 w-5" aria-hidden="true" />
+          )}
+        </button>
+      </div>
+      {hint && <p className="mt-1.5 text-xs text-maroon-500">{hint}</p>}
+    </div>
+  )
+}
+
+/** Maroon submit button with a zari gold sheen and a built-in loading spinner. */
+export function SubmitButton({
+  loading,
+  loadingLabel,
+  children,
+}: {
+  loading: boolean
+  loadingLabel: string
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="submit"
+      disabled={loading}
+      className="group relative flex w-full items-center justify-center gap-2 overflow-hidden rounded-xl bg-gradient-to-r from-maroon-700 to-maroon-600 py-3.5 text-[15px] font-semibold text-marigold-50 shadow-lg shadow-maroon-900/20 transition-all duration-200 hover:from-maroon-800 hover:to-maroon-700 hover:shadow-xl active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-70"
+    >
+      {/* Zari sheen sweep on hover */}
+      <span
+        className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-marigold-200/30 to-transparent transition-transform duration-700 group-hover:translate-x-full"
+        aria-hidden="true"
+      />
+      {loading ? (
+        <>
+          <span className="h-4 w-4 animate-spin rounded-full border-2 border-marigold-100/40 border-t-marigold-100" />
+          {loadingLabel}
+        </>
+      ) : (
+        children
+      )}
+    </button>
+  )
+}
+
+/** Inline error banner styled to fit the saree palette. */
+export function ErrorBanner({ message }: { message: string }) {
+  return (
+    <div
+      role="alert"
+      className="animate-fade-in rounded-xl border border-maroon-200 bg-maroon-50 px-4 py-3 text-sm text-maroon-700"
+    >
+      {message}
+    </div>
+  )
+}

--- a/components/auth/auth-shell.tsx
+++ b/components/auth/auth-shell.tsx
@@ -1,0 +1,193 @@
+'use client'
+
+import Link from 'next/link'
+import Image from 'next/image'
+
+/**
+ * Shared chrome for the sign-in / sign-up screens.
+ *
+ * Layout:
+ *  - Mobile  : single elegant column — a slim zari-gold motif header strip
+ *              above the form card, all on a warm ivory backdrop.
+ *  - Laptop  : split screen — a decorative Banarasi-silk art panel (left)
+ *              beside the form column (right).
+ *
+ * Everything decorative is pure CSS/SVG (silk gradients, paisley + mandala
+ * motifs, zari-thread borders), so the screen renders fully even though most
+ * product imagery in this project is a 0-byte placeholder. Only the brand
+ * logo is a real image asset.
+ */
+
+// Paisley (buta) + dotted "mandala" motif, encoded as an inline SVG data URI so
+// it can tile as a CSS background without shipping an image file.
+const PAISLEY_BG =
+  "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120' viewBox='0 0 120 120'%3E%3Cg fill='none' stroke='%23e6c757' stroke-width='1.1' opacity='0.5'%3E%3Cpath d='M60 18c16 0 30 12 30 30 0 20-18 28-30 28-9 0-17-6-17-15 0-7 5-12 12-12 5 0 9 3 9 8 0 3-2 6-5 6'/%3E%3Ccircle cx='60' cy='48' r='3' fill='%23e6c757' stroke='none'/%3E%3C/g%3E%3Cg fill='%23e6c757' opacity='0.35'%3E%3Ccircle cx='12' cy='12' r='1.6'/%3E%3Ccircle cx='108' cy='108' r='1.6'/%3E%3Ccircle cx='108' cy='12' r='1.6'/%3E%3Ccircle cx='12' cy='108' r='1.6'/%3E%3C/g%3E%3C/svg%3E\")"
+
+// A large, faint concentric mandala used as a watermark on the silk panel.
+function Mandala({ className = '' }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 200 200"
+      className={className}
+      aria-hidden="true"
+      fill="none"
+      stroke="currentColor"
+    >
+      <circle cx="100" cy="100" r="92" strokeWidth="1" />
+      <circle cx="100" cy="100" r="74" strokeWidth="0.8" />
+      <circle cx="100" cy="100" r="52" strokeWidth="0.8" />
+      <circle cx="100" cy="100" r="30" strokeWidth="0.8" />
+      {Array.from({ length: 24 }).map((_, i) => {
+        const a = (i * Math.PI) / 12
+        return (
+          <line
+            key={i}
+            x1={100 + 30 * Math.cos(a)}
+            y1={100 + 30 * Math.sin(a)}
+            x2={100 + 92 * Math.cos(a)}
+            y2={100 + 92 * Math.sin(a)}
+            strokeWidth="0.6"
+          />
+        )
+      })}
+      {Array.from({ length: 12 }).map((_, i) => {
+        const a = (i * Math.PI) / 6
+        return (
+          <circle
+            key={i}
+            cx={100 + 63 * Math.cos(a)}
+            cy={100 + 63 * Math.sin(a)}
+            r="6"
+            strokeWidth="0.8"
+          />
+        )
+      })}
+    </svg>
+  )
+}
+
+interface AuthShellProps {
+  /** Small kicker above the title, e.g. "Welcome back". */
+  eyebrow: string
+  /** Main heading, rendered in the serif display face. */
+  title: string
+  /** Supporting line under the heading. */
+  subtitle: string
+  /** Poetic line shown on the decorative panel (laptop only). */
+  panelQuote: string
+  children: React.ReactNode
+}
+
+export function AuthShell({
+  eyebrow,
+  title,
+  subtitle,
+  panelQuote,
+  children,
+}: AuthShellProps) {
+  return (
+    <div className="min-h-screen w-full bg-[#fdf8f0] text-maroon-900 lg:grid lg:grid-cols-2">
+      {/* Decorative silk art panel (laptop only) */}
+      <aside className="relative hidden overflow-hidden lg:flex lg:flex-col lg:justify-between lg:p-12 xl:p-16">
+        {/* Banarasi silk gradient base */}
+        <div className="absolute inset-0 bg-gradient-to-br from-maroon-800 via-maroon-700 to-[#3a0f14]" />
+        {/* Marigold glow blooming from a corner */}
+        <div className="absolute -right-24 -top-24 h-96 w-96 rounded-full bg-marigold-400/25 blur-3xl" />
+        <div className="absolute -bottom-32 -left-20 h-96 w-96 rounded-full bg-maroon-500/30 blur-3xl" />
+        {/* Tiling paisley motif */}
+        <div
+          className="animate-motif-drift absolute inset-0 opacity-60"
+          style={{ backgroundImage: PAISLEY_BG, backgroundSize: '120px 120px' }}
+          aria-hidden="true"
+        />
+        {/* Faint mandala watermark */}
+        <Mandala className="absolute -right-16 top-1/2 h-[34rem] w-[34rem] -translate-y-1/2 text-marigold-200/20" />
+        {/* Diagonal gold sheen */}
+        <div className="pointer-events-none absolute inset-0 overflow-hidden">
+          <div className="animate-zari-sheen absolute -inset-y-10 left-0 w-1/3 bg-gradient-to-r from-transparent via-marigold-200/15 to-transparent" />
+        </div>
+
+        {/* Panel content */}
+        <div className="relative z-10">
+          <Link href="/" className="inline-flex items-center gap-3" aria-label="Saakie by KNK — home">
+            <span className="rounded-xl bg-white/95 px-3 py-2 shadow-lg ring-1 ring-marigold-200/40">
+              <Image
+                src="/images/saakieLogo.png"
+                alt="Saakie by KNK"
+                width={132}
+                height={40}
+                className="h-8 w-auto object-contain"
+                priority
+              />
+            </span>
+          </Link>
+        </div>
+
+        <div className="relative z-10 max-w-md">
+          <div className="mb-5 h-px w-24 bg-gradient-to-r from-marigold-300 to-transparent" />
+          <p className="font-serif text-3xl leading-snug text-[#fdf0d8] xl:text-4xl">
+            {panelQuote}
+          </p>
+          <p className="mt-6 text-sm uppercase tracking-[0.25em] text-marigold-200/70">
+            Saakie&nbsp;·&nbsp;by&nbsp;KNK
+          </p>
+        </div>
+
+        <div className="relative z-10 flex items-center gap-2 text-xs text-marigold-100/60">
+          <span className="inline-block h-1.5 w-1.5 rounded-full bg-marigold-300" />
+          Handpicked weaves · Authentic craftsmanship · Across India
+        </div>
+      </aside>
+
+      {/* Form column */}
+      <main className="relative flex min-h-screen flex-col">
+        {/* Mobile-only zari motif header strip */}
+        <div className="relative h-2 w-full shrink-0 bg-gradient-to-r from-maroon-700 via-marigold-400 to-maroon-700 lg:hidden" />
+
+        <div className="flex flex-1 items-center justify-center px-5 py-10 sm:px-8">
+          <div className="w-full max-w-md animate-slide-up">
+            {/* Mobile brand logo */}
+            <div className="mb-8 flex justify-center lg:hidden">
+              <Link href="/" aria-label="Saakie by KNK — home">
+                <Image
+                  src="/images/saakieLogo.png"
+                  alt="Saakie by KNK"
+                  width={150}
+                  height={46}
+                  className="h-11 w-auto object-contain"
+                  priority
+                />
+              </Link>
+            </div>
+
+            {/* Heading block */}
+            <div className="mb-8 text-center lg:text-left">
+              <p className="text-xs font-medium uppercase tracking-[0.3em] text-marigold-600">
+                {eyebrow}
+              </p>
+              <h1 className="mt-3 font-serif text-3xl font-bold text-maroon-800 sm:text-4xl">
+                {title}
+              </h1>
+              <p className="mt-3 text-sm text-maroon-700/70">{subtitle}</p>
+              {/* Zari rule */}
+              <div className="mx-auto mt-5 flex items-center justify-center gap-2 lg:mx-0 lg:justify-start">
+                <span className="h-px w-8 bg-gradient-to-r from-transparent to-zari" />
+                <span className="text-zari" aria-hidden="true">
+                  ❖
+                </span>
+                <span className="h-px w-8 bg-gradient-to-l from-transparent to-zari" />
+              </div>
+            </div>
+
+            {children}
+          </div>
+        </div>
+
+        {/* Footer line */}
+        <p className="pb-6 text-center text-xs text-maroon-700/50">
+          © {new Date().getFullYear()} Saakie_byknk · Woven with care
+        </p>
+      </main>
+    </div>
+  )
+}

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,12 @@
 const nextConfig = {
   images: {
     domains: ['res.cloudinary.com', 'images.unsplash.com', 'saakie.vercel.app'],
+    // Allow SVG sources (e.g. /images/placeholder-category.svg) through the
+    // image optimizer. Hardened so a served SVG can never execute scripts:
+    // it is sandboxed with a strict CSP and sent as an attachment.
+    dangerouslyAllowSVG: true,
+    contentDispositionType: 'attachment',
+    contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
   },
   serverExternalPackages: ['@prisma/client'],
   experimental: {

--- a/public/images/placeholder-category.svg
+++ b/public/images/placeholder-category.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="600" viewBox="0 0 600 600" role="img" aria-label="Saakie by KNK category">
+  <defs>
+    <linearGradient id="silk" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7d2128"/>
+      <stop offset="0.55" stop-color="#5e1b21"/>
+      <stop offset="1" stop-color="#3a0f14"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.8" cy="0.15" r="0.9">
+      <stop offset="0" stop-color="#f7a31e" stop-opacity="0.30"/>
+      <stop offset="1" stop-color="#f7a31e" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="paisley" width="120" height="120" patternUnits="userSpaceOnUse">
+      <g fill="none" stroke="#e6c757" stroke-width="1.1" opacity="0.5">
+        <path d="M60 18c16 0 30 12 30 30 0 20-18 28-30 28-9 0-17-6-17-15 0-7 5-12 12-12 5 0 9 3 9 8 0 3-2 6-5 6"/>
+        <circle cx="60" cy="48" r="3" fill="#e6c757" stroke="none"/>
+      </g>
+      <g fill="#e6c757" opacity="0.35">
+        <circle cx="12" cy="12" r="1.6"/>
+        <circle cx="108" cy="108" r="1.6"/>
+        <circle cx="108" cy="12" r="1.6"/>
+        <circle cx="12" cy="108" r="1.6"/>
+      </g>
+    </pattern>
+  </defs>
+
+  <rect width="600" height="600" fill="url(#silk)"/>
+  <rect width="600" height="600" fill="url(#paisley)"/>
+  <rect width="600" height="600" fill="url(#glow)"/>
+
+  <!-- Zari-gold border -->
+  <rect x="20" y="20" width="560" height="560" fill="none" stroke="#c9a227" stroke-width="2" opacity="0.7"/>
+  <rect x="32" y="32" width="536" height="536" fill="none" stroke="#e6c757" stroke-width="1" opacity="0.45"/>
+
+  <!-- Central mandala -->
+  <g transform="translate(300 300)" stroke="#e6c757" fill="none" opacity="0.7">
+    <circle r="92" stroke-width="1.4"/>
+    <circle r="66" stroke-width="1"/>
+    <circle r="40" stroke-width="1"/>
+    <g stroke-width="0.8">
+      <line x1="0" y1="-92" x2="0" y2="92"/>
+      <line x1="-92" y1="0" x2="92" y2="0"/>
+      <line x1="-65" y1="-65" x2="65" y2="65"/>
+      <line x1="-65" y1="65" x2="65" y2="-65"/>
+    </g>
+  </g>
+
+  <text x="300" y="500" text-anchor="middle" fill="#fdf0d8"
+        font-family="Georgia, 'Times New Roman', serif" font-size="34"
+        letter-spacing="6" opacity="0.92">SAAKIE</text>
+  <text x="300" y="528" text-anchor="middle" fill="#e6c757"
+        font-family="Georgia, serif" font-size="13"
+        letter-spacing="8" opacity="0.8">BY KNK</text>
+</svg>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,10 @@ module.exports = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['var(--font-inter)', 'system-ui', 'sans-serif'],
+        serif: ['var(--font-playfair)', 'Georgia', 'serif'],
+      },
       colors: {
         primary: {
           50: '#fef2f2',
@@ -32,7 +36,38 @@ module.exports = {
           700: '#a04509',
           800: '#84360f',
           900: '#702c10',
-        }
+        },
+        // Indian saree palette — deep Banarasi maroon, marigold, and zari gold.
+        // Used across the auth screens and available app-wide.
+        maroon: {
+          50: '#fbf3f3',
+          100: '#f6e1e1',
+          200: '#edc2c4',
+          300: '#df979b',
+          400: '#cd6469',
+          500: '#b94047',
+          600: '#9c2f37',
+          700: '#7d2128',
+          800: '#5e1b21',
+          900: '#4a1418',
+        },
+        marigold: {
+          50: '#fff8eb',
+          100: '#fdecc8',
+          200: '#fbd789',
+          300: '#f9bd4b',
+          400: '#f7a31e',
+          500: '#e6870b',
+          600: '#c86507',
+          700: '#a4480a',
+          800: '#85380f',
+          900: '#702f10',
+        },
+        zari: {
+          DEFAULT: '#c9a227',
+          light: '#e6c757',
+          dark: '#9a7b13',
+        },
       },
       screens: {
         'xs': '475px',


### PR DESCRIPTION
Redesign the login and signup screens with an Indian saree theme, optimized for mobile and laptop:
- Banarasi maroon / marigold / zari-gold palette and Playfair Display serif headings (added via next/font and wired into Tailwind).
- Split-screen on laptop (decorative silk art panel with pure CSS/SVG paisley + mandala motifs and a gold sheen) and a single elegant column on mobile.
- New shared AuthShell + form field components (icon inputs, password show/hide toggle, loading + error states, accessible labels/focus).
- NextAuth credentials logic is unchanged.

Also fix the category placeholder 404: add a saree-themed SVG placeholder, point the category APIs at it, and enable a hardened dangerouslyAllowSVG (sandboxed CSP) so it renders through next/image.