### PR TITLE
feat(ai): Phase 4 — keyword RAG for the Fashion Assistant

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -8,6 +8,7 @@ import {
   productsFromToolResult,
   type ToolResult,
 } from '@/lib/ai/tools';
+import { retrieveContext } from '@/lib/ai/retrieval';
 import { apiError } from '@/lib/server/errors';
 import type { RecommendedProduct } from '@/types/chat';
 
@@ -30,6 +31,13 @@ const MAX_HISTORY = 12;
  * Phase 7 turns this into a configurable agent property.
  */
 const MAX_TOOL_ITERATIONS = 4;
+
+/**
+ * How many products to retrieve into the RAG context block (Phase 4).
+ * 6 is a sweet spot: enough variety for "show me silk under 5k", small
+ * enough that the formatted block stays ~500 tokens.
+ */
+const RAG_LIMIT = 6;
 
 /**
  * Sentinel that delimits the streamed text from the trailing structured
@@ -106,9 +114,38 @@ export async function POST(request: Request) {
       );
     }
 
+    // ─── Phase 4: RAG retrieval ────────────────────────────────────────────
+    // Before we ask Claude anything, run a keyword search over the catalogue
+    // using the user's latest message. Inject the matches into the system
+    // prompt so Claude can answer "show me silk under 5k" in a SINGLE turn
+    // instead of going through a tool_use round-trip.
+    //
+    // Done synchronously here (before the ReadableStream is constructed)
+    // because:
+    //   • The system prompt + RAG products must be ready before we start
+    //     the first Claude turn.
+    //   • Retrieval is a single Prisma round-trip — fast enough to keep on
+    //     the critical path without hurting time-to-first-token noticeably.
+    //   • Phase 7 will move this into the stream and surface "Searching
+    //     catalog…" as a visible status; for now it's invisible plumbing.
+    const lastUserMessage = [...history]
+      .reverse()
+      .find((m) => m.role === 'user' && typeof m.content === 'string');
+    const ragQuery =
+      typeof lastUserMessage?.content === 'string' ? lastUserMessage.content : '';
+
+    const { products: ragProducts, contextBlock: ragContext } =
+      await retrieveContext(ragQuery, { limit: RAG_LIMIT });
+
+    const systemPrompt = ragContext
+      ? `${FASHION_ASSISTANT_SYSTEM_PROMPT}\n\n${ragContext}`
+      : FASHION_ASSISTANT_SYSTEM_PROMPT;
+
     const encoder = new TextEncoder();
 
-    // Aggregated products across all tool calls this request, deduped by id.
+    // Aggregated products across the request, deduped by id. Seeded with the
+    // RAG results so they flow to the UI even when the model never calls a
+    // tool — a "show me silk" question can now finish in one round-trip.
     const collectedProducts: RecommendedProduct[] = [];
     const seenProductIds = new Set<string>();
     const pushProducts = (ps: RecommendedProduct[]) => {
@@ -119,6 +156,7 @@ export async function POST(request: Request) {
         }
       }
     };
+    pushProducts(ragProducts);
 
     // Track the currently-active upstream stream so `cancel()` can abort it.
     let activeStream: ReturnType<typeof anthropic.messages.stream> | null =
@@ -140,7 +178,10 @@ export async function POST(request: Request) {
               model: CHAT_MODEL,
               max_tokens: 1024,
               temperature: 0.7,
-              system: FASHION_ASSISTANT_SYSTEM_PROMPT,
+              // Augmented with the Phase 4 RAG context block when retrieval
+              // found relevant products; falls back to the base prompt
+              // otherwise (e.g. an abstract "how do I drape" question).
+              system: systemPrompt,
               messages: conversation,
               tools: TOOL_DEFINITIONS,
             });

--- a/docs/ai_docs/intro.md
+++ b/docs/ai_docs/intro.md
@@ -268,7 +268,7 @@ For each phase:
 - [ ] Phase 1 — Basic chatbot
 - [x] Phase 2 — Streaming
 - [x] Phase 3 — Tool calling + structured output
-- [ ] Phase 4 — Keyword RAG
+- [x] Phase 4 — Keyword RAG
 - [ ] Phase 5 — Semantic RAG (embeddings + Atlas Vector Search)
 - [ ] Phase 6 — Hybrid search + re-ranking
 - [ ] Phase 7 — Agent

--- a/docs/ai_docs/phase-4.md
+++ b/docs/ai_docs/phase-4.md
@@ -1,0 +1,180 @@
+# Phase 4 — Keyword RAG
+
+**Branch:** `ai-phase-4-rag-keyword` (off `ai-phase-3-tools-2`)
+**Concepts:** Retrieval-Augmented Generation (RAG) · grounding · keyword
+retrieval as a baseline before vectors · formatting context for an LLM ·
+RAG vs tools (when to use which)
+
+---
+
+## What this phase does
+
+Phase 3 let Claude *choose* to look up products via tool calls. Phase 4
+flips the control flow: the server **always retrieves first** — runs a
+keyword search over the catalogue, formats the matches as a compact
+context block, and injects that block into the system prompt before
+Claude reads the user's message.
+
+The effect is biggest on the most common kind of question — *"show me
+silk sarees under ₹5,000"*. In Phase 3 that took two Claude turns
+(decide → tool → observe → reply). In Phase 4 it takes **one**: the
+products are already in the prompt, so the model can answer immediately.
+
+This phase is deliberately the simplest form of RAG — *keyword* RAG. No
+embeddings, no vector DB, no backfill script. Phase 5 will swap the
+retrieval function for vector search, and everything around it stays
+the same — that's the lesson.
+
+## What changed
+
+| File | What |
+|---|---|
+| `lib/ai/keyword-search.ts` | **New.** Shared Prisma query primitive — the `where`-clause builder and the row-to-`RecommendedProduct` mapper. Both Phase 3 tools and Phase 4 RAG go through here so they can't disagree about what "silk under 5k" returns. |
+| `lib/ai/retrieval.ts` | **New.** `retrieveContext(userMessage, { limit })` — runs `keywordSearchProducts({ query }, 6)` and formats the results into a `<retrieved_products>` block plus the matching `RecommendedProduct[]`. |
+| `lib/ai/tools.ts` | `searchProducts` is now a thin wrapper over `keywordSearchProducts`. No behaviour change — same results, same shape. |
+| `lib/ai/prompts.ts` | New "USING RETRIEVED CONTEXT" section at the top, explaining how to consume the block. Tool guidance stays — RAG and tools coexist. |
+| `app/api/chat/route.ts` | One new step at the top of `POST`: retrieve → augment the system prompt → seed `collectedProducts` with the RAG matches. The agent loop, sentinel emit, and cancel handling all unchanged. |
+
+Untouched: `lib/ai/claude.ts`, `types/chat.ts`, `components/chat/*`,
+`prisma/schema.prisma`, `package.json`. The chat UI works as-is — RAG
+products flow through the same `[[PRODUCTS]]` sentinel the tools already
+use.
+
+## The four concepts
+
+### 1. RAG, in one paragraph
+
+Large language models are great at writing — but they don't know your
+DB. RAG closes that gap by **R**etrieving relevant facts at request time
+and **A**ugmenting the prompt with them, so the **G**eneration step has
+ground truth right in front of it. The model isn't "trained" on your
+catalogue; it's just *shown* the relevant pieces fresh on every request.
+
+The whole point: kill a class of hallucinations by making the model
+physically unable to mention products that aren't in the context.
+
+### 2. Keyword retrieval — and why it's the right starting point
+
+Keyword search is the kind every e-commerce site already has: `WHERE
+name LIKE '%silk%' OR description LIKE '%silk%'`. Our `where`-clause
+already does exactly that for the storefront and the Phase 3
+`searchProducts` tool, so RAG reuses it verbatim. No new infrastructure.
+
+Strengths:
+- Zero new dependencies.
+- Predictable: if the word appears in the data, it'll match.
+- Sub-millisecond at our scale (a small `findMany` on an indexed table).
+
+Limitations (the reason Phase 5 exists):
+- **Literal.** *"Something elegant for a winter evening"* returns
+  nothing — no product description contains those exact words.
+- **Synonyms don't help.** A search for "kanjivaram" misses "kanchipuram"
+  results.
+- **Word order is irrelevant.** "Wedding silk" and "silk wedding" are
+  treated identically.
+
+Phase 5 fixes all three by encoding the user's intent as an embedding
+vector and asking the DB for *semantically* nearby products. The
+contract this file exposes (`retrieveContext(userMessage)` →
+`{ products, contextBlock }`) doesn't change.
+
+### 3. Formatting context for an LLM
+
+The retrieved rows aren't dropped into the prompt as raw JSON. They're
+formatted as scannable lines wrapped in XML-style tags:
+
+```
+<retrieved_products>
+Below are products from the live Saakie catalogue that match the user's
+latest message (showing 6 of 23 matches). Refer to them by name when
+recommending. Do NOT mention products that are not in this list, and do
+NOT invent prices, stock, or slugs.
+
+1. Emerald Banarasi Silk — ₹4,200 — Silk Sarees — slug: emerald-banarasi-silk
+   Soft drape silk with gold border, suited to evening receptions.
+2. Royal Blue Kanjivaram — ₹3,900 — Silk Sarees — slug: royal-blue-kanjivaram
+   ...
+</retrieved_products>
+```
+
+Three deliberate choices:
+
+- **XML tags** — Anthropic's own prompt guidance recommends them for
+  delimiting instruction sections. They make it easy for Claude to
+  identify where the catalogue context begins and ends.
+- **Lines, not JSON** — slightly more token-efficient than `[{...}]`
+  and easier to scan in the prompt at debug time. The model handles
+  both equally well.
+- **Deterministic field order** — `name — price — category — slug` on
+  every row. Stable formatting makes the prompt cache-friendly (if you
+  ever turn on Anthropic prompt caching) and easier to diff in tests.
+
+### 4. RAG vs tools — when to use which
+
+Both surface real products. They differ in *who decides*.
+
+| | RAG (Phase 4) | Tools (Phase 3) |
+|---|---|---|
+| Who decides what to fetch | The server (always retrieves) | The model (decides per turn) |
+| Round-trips to Claude | 1 for simple asks | 2+ for any tool call |
+| Best at | First-pass relevance, grounding | Precise filters, follow-ups |
+| Hallucination control | Strong (model only sees retrieved products) | Strong (only real DB rows return) |
+| Cost per request | Fixed RAG tax (~500 tokens) every time | Pay only when tools fire |
+| Multi-turn pronouns | Limited (we only see the last user message) | Strong (model has full context) |
+
+Real production assistants use **both**, exactly like this codebase
+does now. RAG gives the model a free first look so easy questions
+finish in one turn; tools handle anything RAG missed — specific
+filters, full product details, category listings.
+
+## Trade-off: when RAG hurts
+
+Every request now pays a small retrieval tax. For *"how do I drape a
+saree?"* the keyword search runs anyway, returns six products, and they
+end up in the prompt where the model ignores them — wasted bytes.
+
+Acceptable for Phase 4 because:
+- The Prisma query is cheap (~5 ms).
+- The ~500-token context is dwarfed by Claude's per-call overhead.
+- The win on product asks (skipping a whole tool round-trip) more
+  than pays for the loss on non-product asks.
+
+Phase 6 will add a re-ranker that can drop the block entirely when
+relevance scores are too low — at which point this trade-off goes
+away.
+
+## What you'll see vs Phase 3
+
+| Question | Phase 3 | Phase 4 |
+|---|---|---|
+| "Show me silk under ₹5,000" | Two Claude turns: decide → tool → observe → reply. Cards appear after the second turn finishes. | **One Claude turn.** Streaming starts almost immediately; cards appear from the RAG-seeded products. |
+| "Tell me more about <name>" | One tool call (`getProductDetails`). | Same — RAG block doesn't include full details, so the tool is still the right path. |
+| "What categories do you sell?" | Calls `getCategories`. | Same — RAG block is irrelevant; the model still calls the tool. |
+| "What's the weather?" | Polite refusal. | Same — scope-limiting in the system prompt still wins; the empty-or-irrelevant RAG block changes nothing. |
+
+## Try it
+
+1. `npm run dev` on Node 22, open the chat bubble.
+2. Ask *"Show me silk sarees under ₹5,000."* Tokens stream in fast;
+   product cards appear from the RAG-seeded set. Watch the network tab —
+   the chat response should arrive after a single Claude call.
+3. Ask *"Tell me more about <name>"* (use a card from step 2). The model
+   still calls `getProductDetails` — the RAG context was a summary, not
+   the full record.
+4. Ask *"What's a good fabric for winter?"* (no product mention). The
+   model answers from its general knowledge; the RAG block (if any) is
+   ignored or summarized briefly.
+
+## Notes / what's next
+
+- Same `ANTHROPIC_API_KEY` and credit as Phase 3. Per-request input
+  tokens grow by ~500 (the context block) but every product question
+  saves ~2k tokens by skipping a tool round-trip. Net win on shop chat.
+- **Phase 5 — Semantic RAG.** Add an `embedding Float[]` field to
+  `Product`, a backfill script using OpenAI's `text-embedding-3-small`,
+  and a MongoDB Atlas Vector Search index. `lib/ai/retrieval.ts` swaps
+  its internals from keyword search to a `$vectorSearch` aggregation;
+  the route, prompts, and UI don't change.
+- **Phase 6 — Hybrid + re-rank.** Run keyword *and* vector retrieval,
+  merge candidates, then a re-ranker model decides the final order. The
+  industry-default RAG quality bump.

--- a/docs/ai_tree_docs/phase4.md
+++ b/docs/ai_tree_docs/phase4.md
@@ -1,0 +1,257 @@
+User types "Show me silk sarees under ₹5000" in the chat bubble
+  │
+  ▼
+components/chat/chat-window.tsx → sendMessage()
+  │
+  │  1. Seed the empty assistant message (unchanged from Phase 2)
+  │  ──────────────────────────────────────────────────────────────
+  │     userMessage      → { role: "user",      content: "Show me silk..." }
+  │     assistantSeed    → { role: "assistant", content: "" }   ← grows live
+  │     We remember assistantId so streamed chunks find this bubble.
+  │
+  │  2. POST /api/chat  (request body unchanged from Phase 2/3)
+  │     {
+  │       "messages": [
+  │         { "role": "assistant", "content": "Hello! I'm your..." },
+  │         { "role": "user",      "content": "Show me silk sarees..." }
+  │       ]
+  │     }
+  ▼
+app/api/chat/route.ts → POST handler
+  │  1. Parse JSON body → `messages`
+  │  2. Validate non-empty array (else 400)
+  │  3. Filter to user/assistant turns with non-empty content
+  │  4. Slice last 12 (MAX_HISTORY) → bounds cost / latency
+  │  5. Map to Claude shape: [{ role, content }, ...]
+  │     (steps 1–5 unchanged from Phase 2/3 — RAG is a NEW step BEFORE
+  │      the stream is built, not a change to history handling)
+  │
+  │  6. ★ NEW IN PHASE 4 ★ — RAG retrieval BEFORE we touch Claude
+  │  ──────────────────────────────────────────────────────────────
+  │     const lastUserMessage = [...history].reverse()
+  │                              .find(m => m.role === 'user')
+  │     const ragQuery        = lastUserMessage?.content ?? ''
+  │
+  │     const { products: ragProducts, contextBlock: ragContext } =
+  │       await retrieveContext(ragQuery, { limit: 6 })
+  │            │
+  │            ▼
+  │     lib/ai/retrieval.ts → retrieveContext()
+  │       │
+  │       │  a. Trim query. Empty? return { products:[], contextBlock:'' }
+  │       │  b. Call keywordSearchProducts({ query }, 6)
+  │       │       │
+  │       │       ▼
+  │       │     lib/ai/keyword-search.ts → keywordSearchProducts()
+  │       │       │
+  │       │       │  • buildProductWhere({ query: "Show me silk sarees..." })
+  │       │       │      where = {
+  │       │       │        isActive: true,
+  │       │       │        OR: [
+  │       │       │          { name: { contains: "Show me silk...", insensitive }},
+  │       │       │          { description: { contains: ..., insensitive }},
+  │       │       │          { tags: { has: "Show me silk..." }},
+  │       │       │        ],
+  │       │       │      }
+  │       │       │  • Promise.all([
+  │       │       │      prisma.product.findMany({ where, take:6, ... }),
+  │       │       │      prisma.product.count({ where }),
+  │       │       │    ])
+  │       │       │  • rows.map(toRow) → KeywordProductRow[] {
+  │       │       │        id, name, slug, price, description,
+  │       │       │        shortDescription, categoryName, imageUrl
+  │       │       │      }
+  │       │       │
+  │       │       │  ← Returns { rows: KeywordProductRow[], totalFound: N }
+  │       │       ▼
+  │       │     Back in retrieveContext()
+  │       │
+  │       │  c. No rows? return { products:[], contextBlock:'' }
+  │       │  d. Build the context block:
+  │       │       <retrieved_products>
+  │       │       Below are products from the live Saakie catalogue
+  │       │       that match the user's latest message (showing 6 of 23
+  │       │       matches). Refer to them by name when recommending.
+  │       │       Do NOT mention products that are not in this list,
+  │       │       and do NOT invent prices, stock, or slugs.
+  │       │
+  │       │       1. Emerald Banarasi Silk — ₹4,200 — Silk Sarees — slug: emerald-banarasi-silk
+  │       │          Soft drape silk with gold border, suited to evening receptions.
+  │       │       2. Royal Blue Kanjivaram — ₹3,900 — Silk Sarees — slug: royal-blue-kanjivaram
+  │       │          Classic temple-border weave, festival-ready.
+  │       │       ...4 more...
+  │       │       </retrieved_products>
+  │       │
+  │       │  e. Map rows → RecommendedProduct[] (same shape ProductCardMini
+  │       │     and Phase 3's [[PRODUCTS]] sentinel already use).
+  │       │
+  │       │  Returns { products, contextBlock }
+  │       ▼
+  │     ragProducts: RecommendedProduct[] = [...6 items...]
+  │     ragContext : string              = "<retrieved_products>...</retrieved_products>"
+  │
+  │  7. ★ Augment the system prompt with the retrieved context ★
+  │  ──────────────────────────────────────────────────────────────
+  │     systemPrompt = ragContext
+  │       ? `${FASHION_ASSISTANT_SYSTEM_PROMPT}\n\n${ragContext}`
+  │       : FASHION_ASSISTANT_SYSTEM_PROMPT
+  │
+  │     What Claude sees as `system` is now:
+  │
+  │       You are the Fashion Assistant for "Saakie"...
+  │       VOICE & STYLE / WHAT YOU HELP WITH / ...
+  │
+  │       USING RETRIEVED CONTEXT (READ THIS FIRST)
+  │         A <retrieved_products> block may be appended below this
+  │         prompt with sarees that already match the user's latest
+  │         message. Prefer those products...
+  │
+  │       TOOLS (USE THEM — DO NOT INVENT)
+  │         - searchProducts, getProductDetails, getCategories
+  │
+  │       <retrieved_products>
+  │       Below are products from the live Saakie catalogue...
+  │       1. Emerald Banarasi Silk — ₹4,200 — ...
+  │       ...
+  │       </retrieved_products>
+  │
+  │  8. ★ Seed collectedProducts with RAG matches ★
+  │  ──────────────────────────────────────────────────────────────
+  │     pushProducts(ragProducts)
+  │       ↑ The 6 RAG products go straight into collectedProducts (deduped
+  │         by id). They will reach the UI via the [[PRODUCTS]] sentinel
+  │         EVEN IF the model never calls a tool — which is the whole
+  │         point of Phase 4: single-turn product asks finish in one
+  │         Claude call.
+  ▼
+═══════════════ AGENT LOOP — iteration 1 ═══════════════════════════════
+  │
+  │  9. Ask Claude — with augmented system prompt AND tools
+  │  ──────────────────────────────────────────────────────────────
+  │     const claudeStream = anthropic.messages.stream({
+  │       model:       "claude-haiku-4-5",
+  │       max_tokens:  1024,
+  │       temperature: 0.7,
+  │       system:      systemPrompt,           ← NOW INCLUDES RAG CONTEXT
+  │       messages:    conversation,
+  │       tools:       TOOL_DEFINITIONS,       ← still available, just often unused
+  │     })
+  │     activeStream = claudeStream
+  │
+  │     What changes vs Phase 3:
+  │     • Phase 3: model sees just rules + tool list → MUST call
+  │                searchProducts to know any product. Two-turn answer.
+  │     • Phase 4: model already sees the 6 matching sarees in
+  │                <retrieved_products>. It can write the reply DIRECTLY.
+  │                Tool call becomes optional, not mandatory.
+  │
+  │ 10. Stream text deltas to the user — unchanged
+  │  ──────────────────────────────────────────────────────────────
+  │     for await (event of claudeStream) {
+  │       if (event.type === 'content_block_delta' &&
+  │           event.delta.type === 'text_delta') {
+  │         controller.enqueue(encoder.encode(event.delta.text))
+  │       }
+  │     }
+  │
+  │     What Claude actually streams here, with RAG in place:
+  │       "I found six lovely silk sarees in your budget. The Emerald
+  │        Banarasi at ₹4,200 has a soft drape that suits evening
+  │        receptions. The Royal Blue Kanjivaram at ₹3,900 is more
+  │        festival-friendly..."
+  │
+  │     Notice: every product name + price comes verbatim from the
+  │     <retrieved_products> block. The model is GROUNDED — physically
+  │     cannot invent products that aren't in the block.
+  │
+  │ 11. Inspect the finished turn
+  │  ──────────────────────────────────────────────────────────────
+  │     const final = await claudeStream.finalMessage()
+  │     activeStream = null
+  │
+  │     final.stop_reason === 'end_turn'   ← model is done, RAG was enough
+  │     → break out of the loop. NO TOOL CALL NEEDED.
+  │
+  │  (If the question had been "tell me more about the emerald one",
+  │   the model would have emitted a getProductDetails tool_use here —
+  │   RAG covers the summary, tools cover the deep details. The loop
+  │   would run a 2nd iteration just like Phase 3, see docs/ai_tree_docs/phase3.md.)
+  ▼
+═══════════════ AFTER THE LOOP ═══════════════════════════════════════
+  │
+  │ 12. Emit the trailing PRODUCTS sentinel (unchanged from Phase 3)
+  │  ──────────────────────────────────────────────────────────────
+  │     if (collectedProducts.length && !clientAborted) {
+  │       const payload = JSON.stringify({ products: collectedProducts })
+  │       controller.enqueue(encoder.encode(`\n\n[[PRODUCTS]]${payload}`))
+  │     }
+  │     controller.close()
+  │
+  │     collectedProducts here = the 6 RAG products from step 8
+  │     (no tool ran, so nothing was added during the loop).
+  │
+  │     Final bytes on the wire:
+  │       "I found six lovely silk sarees...\n\n[[PRODUCTS]]{"products":[...6...]}"
+  │
+  │ 13. cancel() — unchanged from Phase 3
+  │  ──────────────────────────────────────────────────────────────
+  │     cancel() { clientAborted = true; activeStream?.abort() }
+  ▼
+components/chat/chat-window.tsx → read loop (unchanged from Phase 3)
+  │
+  │ 14. Split on the sentinel, attach products[] to the message
+  │  ──────────────────────────────────────────────────────────────
+  │     visibleText = received.slice(0, indexOf("\n\n[[PRODUCTS]]"))
+  │     products    = JSON.parse(received.slice(after sentinel)).products
+  │     setMessages(prev => prev.map(m =>
+  │       m.id === assistantId
+  │         ? { ...m, content: visibleText, products }
+  │         : m
+  │     ))
+  │
+  │ 15. React renders — unchanged
+  │     • message.content        → ChatMessage bubble (streamed text)
+  │     • message.products?.map  → ProductCardMini grid under the bubble
+  ▼
+User sees:
+  ┌────────────────────────────────────────────────────────┐
+  │  🤖  I found six lovely silk sarees in your budget.    │
+  │      The Emerald Banarasi at ₹4,200 has a soft drape   │
+  │      that suits evening receptions. The Royal Blue     │
+  │      Kanjivaram at ₹3,900 is more festival-friendly…   │
+  │                                                        │
+  │      [🖼  Emerald Banarasi    ₹4,200]                  │
+  │      [🖼  Royal Blue Kanj.    ₹3,900]                  │
+  │      [🖼  Ivory Pochampally   ₹3,600]                  │
+  │      ...                                                │
+  └────────────────────────────────────────────────────────┘
+
+
+─── Pin these for Phase 5 / 6 ─────────────────────────────────────────
+
+• RAG = "look stuff up BEFORE you generate."
+  Tools  = "let the model decide what to look up DURING generation."
+  Phase 4 always runs RAG; tools still available as a fallback.
+
+• Token cost moved, didn't disappear:
+  Phase 3 typical: 1× input (rules+tools) + tool call + 2× input (above
+                   + tool_result) + output ≈ a "two-turn" bill.
+  Phase 4 typical: 1× input (rules+tools+RAG context) + output ≈ ONE turn.
+  For pure non-product asks ("how do I drape?"), Phase 4 pays a small
+  RAG tax (~500 tokens of unused context) that Phase 3 wouldn't have.
+  Net win on shop questions, small loss on abstract ones.
+
+• Keyword retrieval is LITERAL. "Something elegant for a winter evening"
+  finds nothing because no description contains those exact words.
+  Phase 5 fixes this with embeddings: turn the query into a semantic
+  vector, find the nearest product vectors in MongoDB Atlas Vector Search.
+  The retrieveContext() signature and the rest of the route stay the same.
+
+• Grounding via prompt is fragile if the user can manipulate the input
+  (prompt injection). Phase 9 adds guardrails — output validation that
+  only RAG-or-tool-returned product IDs reach the UI's sentinel.
+
+• retrieveContext() and keywordSearchProducts() are deliberately
+  decoupled — Phase 5 will replace ONLY the body of keywordSearchProducts
+  (or add a sibling vector-search.ts that retrieval.ts delegates to),
+  with no changes to the route, prompts, or UI.

--- a/lib/ai/keyword-search.ts
+++ b/lib/ai/keyword-search.ts
@@ -1,0 +1,188 @@
+import 'server-only';
+import type { Prisma } from '@prisma/client';
+import prisma from '@/lib/prisma';
+import type { RecommendedProduct } from '@/types/chat';
+
+/**
+ * Shared keyword search primitive for the Fashion Assistant.
+ *
+ * Phase 3 introduced tool calling: Claude calls `searchProducts` when it
+ * decides it needs product data. Phase 4 introduces RAG: the server runs the
+ * same search on every request *before* Claude sees the message and injects
+ * the matches as context.
+ *
+ * Both paths want the same `where`-clause logic and the same product shape
+ * out. Keeping them in one place means there's no chance for the tool's
+ * results and the RAG context to disagree about what "silk under 5k" returns.
+ *
+ * Provider-agnostic filename (`keyword-search.ts`, not `claude-search.ts`):
+ * this file is pure Prisma — it doesn't know or care which LLM consumes the
+ * results. Phase 5 will add `lib/ai/vector-search.ts` next to it.
+ */
+
+const PLACEHOLDER_IMAGE = '/images/placeholder-product.jpg';
+
+export interface KeywordSearchFilters {
+  /** Free-text query — matched against name, description, and tags. */
+  query?: string;
+  /** Narrow to a single category by slug. */
+  categorySlug?: string;
+  /** Min price in ₹. */
+  minPrice?: number;
+  /** Max price in ₹. */
+  maxPrice?: number;
+  /** Match an entry in Product.occasion[]. */
+  occasion?: string;
+  /** Case-insensitive substring match on Product.material. */
+  material?: string;
+  /** Drop items with stock <= 0 when true. */
+  inStockOnly?: boolean;
+}
+
+/**
+ * Build the Prisma `where` clause for an active-products search.
+ *
+ * Resolves `categorySlug` against the DB to get the internal `categoryId`.
+ * If the slug doesn't exist, the category filter is silently dropped — we'd
+ * rather show a broad result than confuse the user (or Claude) with zero
+ * matches due to a misspelled slug.
+ */
+export async function buildProductWhere(
+  filters: KeywordSearchFilters
+): Promise<Prisma.ProductWhereInput> {
+  const where: Prisma.ProductWhereInput = { isActive: true };
+
+  if (filters.categorySlug) {
+    const cat = await prisma.category.findUnique({
+      where: { slug: filters.categorySlug },
+      select: { id: true },
+    });
+    if (cat) where.categoryId = cat.id;
+  }
+
+  if (filters.minPrice !== undefined || filters.maxPrice !== undefined) {
+    where.price = {
+      ...(filters.minPrice !== undefined ? { gte: filters.minPrice } : {}),
+      ...(filters.maxPrice !== undefined ? { lte: filters.maxPrice } : {}),
+    };
+  }
+
+  if (filters.inStockOnly) where.stock = { gt: 0 };
+
+  if (filters.material) {
+    where.material = { contains: filters.material, mode: 'insensitive' };
+  }
+
+  if (filters.occasion) {
+    where.occasion = { has: filters.occasion };
+  }
+
+  if (filters.query?.trim()) {
+    const term = filters.query.trim();
+    where.OR = [
+      { name: { contains: term, mode: 'insensitive' } },
+      { description: { contains: term, mode: 'insensitive' } },
+      { tags: { has: term } },
+    ];
+  }
+
+  return where;
+}
+
+/**
+ * Internal row shape — selected once, mapped to RecommendedProduct in
+ * `keywordSearchProducts` and to a context-formatted line in `retrieval.ts`.
+ *
+ * The description is included so RAG can ground the model on a one-line
+ * preview without an extra DB hit. Tool-calling clients don't need it but
+ * the over-select is cheap (single column from a row we already fetched).
+ */
+export interface KeywordProductRow {
+  id: string;
+  name: string;
+  slug: string;
+  price: number;
+  description: string;
+  shortDescription: string | null;
+  categoryName: string;
+  imageUrl: string;
+}
+
+function toRow(p: {
+  id: string;
+  name: string;
+  slug: string;
+  price: number;
+  description: string;
+  shortDescription: string | null;
+  images: { url: string }[];
+  category: { name: string } | null;
+}): KeywordProductRow {
+  return {
+    id: p.id,
+    name: p.name,
+    slug: p.slug,
+    price: p.price,
+    description: p.description,
+    shortDescription: p.shortDescription,
+    categoryName: p.category?.name ?? '',
+    imageUrl: p.images[0]?.url ?? PLACEHOLDER_IMAGE,
+  };
+}
+
+/**
+ * Map a fetched row to the wire-shape the chat UI's `ProductCardMini`
+ * expects. RAG and tools both go through this so the cards render
+ * identically whichever path surfaced them.
+ */
+export function rowToRecommendedProduct(
+  row: KeywordProductRow
+): RecommendedProduct {
+  return {
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    price: row.price,
+    image: row.imageUrl,
+    category: row.categoryName,
+  };
+}
+
+/**
+ * Keyword search with a hard cap on returned rows.
+ *
+ * Used by:
+ *   - `lib/ai/tools.ts` → `searchProducts` (Phase 3)
+ *   - `lib/ai/retrieval.ts` → `retrieveContext` (Phase 4)
+ *
+ * Returns both the row form (so RAG can format descriptions into the context
+ * block) and the `totalFound` count (so Claude can report "6 of 23" instead
+ * of pretending there are only 6 matches in the entire catalogue).
+ */
+export async function keywordSearchProducts(
+  filters: KeywordSearchFilters,
+  limit: number
+): Promise<{ rows: KeywordProductRow[]; totalFound: number }> {
+  const where = await buildProductWhere(filters);
+
+  const [rows, totalFound] = await Promise.all([
+    prisma.product.findMany({
+      where,
+      take: limit,
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        price: true,
+        description: true,
+        shortDescription: true,
+        images: { select: { url: true }, take: 1, orderBy: { order: 'asc' } },
+        category: { select: { name: true } },
+      },
+    }),
+    prisma.product.count({ where }),
+  ]);
+
+  return { rows: rows.map(toRow), totalFound };
+}

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -7,9 +7,14 @@
  * the first message of every conversation and shapes everything the model says.
  *
  * Phase 3: the assistant now has three real tools (see `lib/ai/tools.ts`)
- * that hit the live product DB. The prompt is updated to tell the model
- * *when* to reach for each tool and how to talk about the results — without
- * inventing facts the tools didn't return.
+ * that hit the live product DB. The prompt tells the model *when* to reach
+ * for each tool and how to talk about the results without inventing facts.
+ *
+ * Phase 4: keyword RAG (see `lib/ai/retrieval.ts`). The chat route prepends
+ * a `<retrieved_products>` block to this prompt at request time with
+ * catalogue matches for the user's latest message — so most product
+ * questions can be answered without a tool round-trip. The "USING RETRIEVED
+ * CONTEXT" section below tells the model how to consume that block.
  */
 export const FASHION_ASSISTANT_SYSTEM_PROMPT = `
 You are the Fashion Assistant for "Saakie", an online saree and ethnic-wear
@@ -24,6 +29,20 @@ WHAT YOU HELP WITH
 - Choosing sarees by occasion (wedding, festival, office, casual), fabric
   (silk, cotton, georgette…), colour, budget, and styling.
 - General fashion and draping advice for sarees and ethnic wear.
+
+USING RETRIEVED CONTEXT (READ THIS FIRST)
+A <retrieved_products> block may be appended below this prompt with sarees
+that already match the user's latest message. When the block is present,
+prefer those products in your reply — they are your ground truth for names,
+prices, and slugs. Do NOT contradict the block, and do NOT mention products
+that are not in it. If the block is empty or absent, behave as if it weren't
+there and use the tools below normally. The block does NOT replace the tools:
+- Single-turn product asks ("show me silk under ₹5,000") → usually
+  answerable straight from the block; no tool call needed.
+- "Tell me more about <name>" follow-ups → call getProductDetails with the
+  slug from the block.
+- Anything outside the block (other categories, specific filters, full
+  product info) → call the tools.
 
 TOOLS (USE THEM — DO NOT INVENT)
 You have three tools that hit the live catalogue. Prefer calling a tool over

--- a/lib/ai/retrieval.ts
+++ b/lib/ai/retrieval.ts
@@ -1,0 +1,139 @@
+import 'server-only';
+import {
+  keywordSearchProducts,
+  rowToRecommendedProduct,
+  type KeywordProductRow,
+} from '@/lib/ai/keyword-search';
+import type { RecommendedProduct } from '@/types/chat';
+
+/**
+ * Retrieval-Augmented Generation (RAG) — Phase 4: keyword retrieval.
+ *
+ * Phase 3 gave Claude tools it could *choose* to call. Phase 4 inverts the
+ * control flow: the server runs a search on every chat request, formats the
+ * matches as a compact text block, and injects that block into the system
+ * prompt — so Claude already has relevant products in context before it
+ * starts writing the reply.
+ *
+ * Why this matters: most product questions can be answered in ONE Claude
+ * call instead of two (decide → tool → observe → reply). The model is also
+ * "grounded" — it can only name products that are in the block, which kills
+ * a whole class of hallucinations.
+ *
+ * Why *keyword* retrieval (not embeddings) in this phase: it's the cheapest
+ * possible RAG. No vector index, no embedding model, no backfill script —
+ * just the same Prisma `OR` query Phase 3 already uses. Phase 5 will replace
+ * this function's body with a vector search; the call sites, the context
+ * format, and the system-prompt contract all stay the same.
+ *
+ * Trade-offs to be aware of:
+ * - Keyword recall is *literal*. "Something elegant for winter" returns
+ *   nothing useful because no product description contains those exact
+ *   words. Phase 5 fixes that with semantic matching.
+ * - We pay a Prisma roundtrip on every request, even for abstract questions
+ *   like "how do I drape a saree". That's fine at this scale — Phase 6
+ *   could cache by query if it becomes a hotspot.
+ * - We don't rewrite the query (no extra LLM call) — the user message goes
+ *   in verbatim. Multi-turn pronoun resolution is a Phase 6/8 concern.
+ */
+
+const DEFAULT_LIMIT = 6;
+const DESCRIPTION_PREVIEW_CHARS = 120;
+
+interface RetrieveContextOptions {
+  /** Cap on retrieved products (default 6). */
+  limit?: number;
+}
+
+export interface RetrievedContext {
+  /** Products formatted for the chat UI sentinel; same shape as tools yield. */
+  products: RecommendedProduct[];
+  /**
+   * A ready-to-append string of the form
+   * `<retrieved_products>...</retrieved_products>` for the system prompt, or
+   * empty when retrieval found nothing / the query was blank.
+   */
+  contextBlock: string;
+}
+
+/**
+ * Run a keyword search against the live catalogue using the user's latest
+ * message as the query, then format the results for prompt injection.
+ *
+ * Returns an empty `contextBlock` when the query is blank or no products
+ * matched — the route checks for emptiness before deciding whether to
+ * augment the prompt at all.
+ */
+export async function retrieveContext(
+  userMessage: string,
+  opts: RetrieveContextOptions = {}
+): Promise<RetrievedContext> {
+  const query = userMessage.trim();
+  if (!query) {
+    return { products: [], contextBlock: '' };
+  }
+
+  const limit = opts.limit ?? DEFAULT_LIMIT;
+  const { rows, totalFound } = await keywordSearchProducts({ query }, limit);
+
+  if (rows.length === 0) {
+    return { products: [], contextBlock: '' };
+  }
+
+  return {
+    products: rows.map(rowToRecommendedProduct),
+    contextBlock: formatContextBlock(rows, { totalFound }),
+  };
+}
+
+/**
+ * Format the retrieved rows as a deterministic, scannable block for the
+ * model. XML-style tags around the block (`<retrieved_products>...
+ * </retrieved_products>`) are the convention Anthropic recommends for
+ * delimiting instruction sections — they make it easy for Claude to "see"
+ * where the catalogue context begins and ends.
+ *
+ * Per-product shape:
+ *   N. <name> — ₹<price> — <category> — slug: <slug>
+ *      <one-line description, truncated>
+ *
+ * Same fields the model would get from a `searchProducts` tool result, but
+ * presented as natural-language lines instead of JSON. The model handles
+ * both forms equally well; lines are slightly more token-efficient and a
+ * bit easier to read in the prompt at debug time.
+ */
+function formatContextBlock(
+  rows: KeywordProductRow[],
+  meta: { totalFound: number }
+): string {
+  const header =
+    `Below are products from the live Saakie catalogue that match the user's ` +
+    `latest message (showing ${rows.length} of ${meta.totalFound} matches). ` +
+    `Refer to them by name when recommending. Do NOT mention products that ` +
+    `are not in this list, and do NOT invent prices, stock, or slugs.`;
+
+  const lines = rows.map((row, i) => {
+    const description = previewDescription(row);
+    const head = `${i + 1}. ${row.name} — ₹${row.price.toLocaleString('en-IN')} — ${row.categoryName} — slug: ${row.slug}`;
+    return description ? `${head}\n   ${description}` : head;
+  });
+
+  return [
+    '<retrieved_products>',
+    header,
+    '',
+    ...lines,
+    '</retrieved_products>',
+  ].join('\n');
+}
+
+function previewDescription(row: KeywordProductRow): string {
+  const raw = (row.shortDescription ?? row.description ?? '').trim();
+  if (!raw) return '';
+  // Collapse whitespace so a multi-line description doesn't break our
+  // per-product two-line layout, then truncate with an ellipsis.
+  const oneLine = raw.replace(/\s+/g, ' ');
+  return oneLine.length > DESCRIPTION_PREVIEW_CHARS
+    ? `${oneLine.slice(0, DESCRIPTION_PREVIEW_CHARS - 1).trimEnd()}…`
+    : oneLine;
+}

--- a/lib/ai/tools.ts
+++ b/lib/ai/tools.ts
@@ -1,6 +1,10 @@
 import 'server-only';
 import { z } from 'zod';
 import prisma from '@/lib/prisma';
+import {
+  keywordSearchProducts,
+  rowToRecommendedProduct,
+} from '@/lib/ai/keyword-search';
 import type { RecommendedProduct } from '@/types/chat';
 
 /**
@@ -107,64 +111,12 @@ const SearchProductsInput = z
 
 async function searchProducts(rawInput: unknown) {
   const input = SearchProductsInput.parse(rawInput);
-  const limit = input.limit ?? 6;
 
-  const where: Record<string, unknown> = { isActive: true };
-
-  if (input.categorySlug) {
-    const cat = await prisma.category.findUnique({
-      where: { slug: input.categorySlug },
-      select: { id: true },
-    });
-    if (cat) where.categoryId = cat.id;
-  }
-
-  if (input.minPrice !== undefined || input.maxPrice !== undefined) {
-    where.price = {
-      ...(input.minPrice !== undefined ? { gte: input.minPrice } : {}),
-      ...(input.maxPrice !== undefined ? { lte: input.maxPrice } : {}),
-    };
-  }
-
-  if (input.inStockOnly) where.stock = { gt: 0 };
-  if (input.material) {
-    where.material = { contains: input.material, mode: 'insensitive' };
-  }
-  if (input.occasion) where.occasion = { has: input.occasion };
-
-  if (input.query?.trim()) {
-    const term = input.query.trim();
-    where.OR = [
-      { name: { contains: term, mode: 'insensitive' } },
-      { description: { contains: term, mode: 'insensitive' } },
-      { tags: { has: term } },
-    ];
-  }
-
-  const rows = await prisma.product.findMany({
-    where,
-    take: limit,
-    orderBy: { createdAt: 'desc' },
-    select: {
-      id: true,
-      name: true,
-      slug: true,
-      price: true,
-      images: { select: { url: true }, take: 1, orderBy: { order: 'asc' } },
-      category: { select: { name: true } },
-    },
-  });
-
-  const totalFound = await prisma.product.count({ where });
-
-  const products: RecommendedProduct[] = rows.map((p) => ({
-    id: p.id,
-    name: p.name,
-    slug: p.slug,
-    price: p.price,
-    image: p.images[0]?.url ?? PLACEHOLDER_IMAGE,
-    category: p.category?.name ?? '',
-  }));
+  // The where-clause + Prisma query + RecommendedProduct mapping all live in
+  // lib/ai/keyword-search.ts so Phase 4 RAG can reuse the exact same logic.
+  // This tool is now a thin wrapper: validate args, delegate, summarise.
+  const { rows, totalFound } = await keywordSearchProducts(input, input.limit ?? 6);
+  const products: RecommendedProduct[] = rows.map(rowToRecommendedProduct);
 
   return {
     products,


### PR DESCRIPTION
Retrieve relevant catalogue products from MongoDB on every request and inject them into the system prompt as a <retrieved_products> block, so Claude can answer "show me silk under 5k" in ONE turn instead of going through a tool round-trip.

New files:
  - lib/ai/keyword-search.ts: shared Prisma search primitive (where-clause
    + row -> RecommendedProduct mapper). Phase 3 tools and Phase 4 RAG both go through this, so they can't disagree about what "silk under 5k" returns.
  - lib/ai/retrieval.ts: retrieveContext(userMessage) -> keyword search + formatted <retrieved_products> block + RecommendedProduct[]. Phase 5 will swap the body for vector search without changing the surface.

Wiring:
  - app/api/chat/route.ts retrieves before the stream starts, augments the system prompt when context is non-empty, and seeds the collected-products set so RAG matches reach the [[PRODUCTS]] sentinel even when no tool fires.
  - lib/ai/prompts.ts gains a "USING RETRIEVED CONTEXT" section that tells the model how to consume the block (prefer it, never contradict it, fall back to tools for gaps).
  - lib/ai/tools.ts searchProducts now delegates to the shared helper. Zero behaviour change for tool callers.

RAG and tools coexist on purpose: RAG handles single-turn product asks cheaply; tools handle precise filters and follow-ups.

docs/ai_docs/phase-4.md (learning note) and docs/ai_tree_docs/phase4.md (request-flow tree) added; intro.md section 7 ticked.