### PR TITLE
fix(header): restore black header + always-visible mobile nav row

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -807,18 +807,47 @@
 /* Pads around the iOS notch / home indicator. Pairs with viewport-fit=cover
    (set in the layout viewport export). Applied to the sticky header, footer and
    bottom nav so their backgrounds extend edge-to-edge without clipping content. */
+/* These ONLY apply when the site runs as an installed PWA (display-mode:
+   standalone). In a normal browser tab the chrome already covers the notch, and
+   env(safe-area-inset-top) shifts as the address bar shows/hides on scroll —
+   applying it there made the sticky header visibly bounce. So in a browser tab
+   these resolve to 0. */
 @layer utilities {
+  .pt-safe,
+  .pb-safe,
+  .pl-safe,
+  .pr-safe {
+    --safe-top: 0px;
+    --safe-bottom: 0px;
+    --safe-left: 0px;
+    --safe-right: 0px;
+  }
   .pt-safe {
-    padding-top: env(safe-area-inset-top);
+    padding-top: var(--safe-top);
   }
   .pb-safe {
-    padding-bottom: env(safe-area-inset-bottom);
+    padding-bottom: var(--safe-bottom);
   }
   .pl-safe {
-    padding-left: env(safe-area-inset-left);
+    padding-left: var(--safe-left);
   }
   .pr-safe {
-    padding-right: env(safe-area-inset-right);
+    padding-right: var(--safe-right);
+  }
+}
+
+@media all and (display-mode: standalone) {
+  .pt-safe {
+    --safe-top: env(safe-area-inset-top);
+  }
+  .pb-safe {
+    --safe-bottom: env(safe-area-inset-bottom);
+  }
+  .pl-safe {
+    --safe-left: env(safe-area-inset-left);
+  }
+  .pr-safe {
+    --safe-right: env(safe-area-inset-right);
   }
 }
 

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -95,7 +95,7 @@ export function Header() {
   }, [mobileMenuOpen])
 
   return (
-    <header className="sticky top-0 z-50 bg-white shadow-sm pt-safe">
+    <header className="sticky top-0 z-50 bg-black shadow-sm pt-safe">
       {/* <div className="bg-red-600 text-white py-2 text-center text-sm">
         <p>Free shipping on orders above ₹2,999 | Cash on Delivery Available</p>
       </div> */}
@@ -236,6 +236,37 @@ export function Header() {
                 className="text-sm font-medium text-white hover:text-gray-300"
               >
                 Sign In
+              </Link>
+            )}
+          </div>
+        </div>
+
+        {/* Mobile: horizontally-scrollable nav row. The logo takes the full
+            width of the top bar on mobile, so the links live on a second row
+            here (and remain available in the hamburger menu too). Always
+            visible — it stays put as the page scrolls. */}
+        <div className="lg:hidden -mx-4 sm:-mx-6 border-t border-gray-800">
+          <div className="flex items-center gap-1 overflow-x-auto px-4 sm:px-6 py-2 scrollbar-hide">
+            {navigation.map((item) => (
+              <Link
+                key={item.name}
+                href={item.href}
+                className={cn(
+                  'whitespace-nowrap rounded-full px-3 py-1.5 text-sm font-medium transition-colors',
+                  pathname === item.href
+                    ? 'bg-white/15 text-white'
+                    : 'text-gray-300 hover:text-white hover:bg-white/10'
+                )}
+              >
+                {item.name}
+              </Link>
+            ))}
+            {isAdmin && (
+              <Link
+                href="/admin"
+                className="whitespace-nowrap rounded-full px-3 py-1.5 text-sm font-medium text-gray-300 hover:text-white hover:bg-white/10 transition-colors"
+              >
+                Admin
               </Link>
             )}
           </div>


### PR DESCRIPTION
A merge from main flipped the header to bg-white while the controls stayed text-white, making the icons invisible. Restore the black header and add a mobile nav-link row so the sections are reachable without the hamburger.

- restore bg-black on the sticky header (white controls now visible)
- add an always-visible, horizontally-scrollable nav row on mobile (Home/New Arrivals/All Products/Sale/Posts + Admin); links remain in the hamburger menu too
- apply safe-area inset padding only in standalone (installed PWA) mode, not in a browser tab where the shifting address bar made the sticky header bounce on scroll