### PR TITLE
fix(cart): return updated cart from item DELETE; guard empty render

### DIFF
--- a/app/api/cart/items/[itemId]/route.ts
+++ b/app/api/cart/items/[itemId]/route.ts
@@ -82,7 +82,18 @@ export async function DELETE(
 
     await prisma.cartItem.delete({ where: { id: itemId } });
 
-    return NextResponse.json({ message: 'Item removed from cart' });
+    // Return the full updated cart (same shape as PATCH and GET /api/cart) so
+    // the client can setCart(...) directly. Previously this returned only a
+    // { message } object, which made cart.items undefined and crashed the UI.
+    const updatedCart = await prisma.cart.findUnique({
+      where: { userId: r.id },
+      include: cartInclude,
+    });
+    const items = updatedCart?.items ?? [];
+    const subtotal = items.reduce((t, i) => t + i.price * i.quantity, 0);
+    const itemCount = items.reduce((c, i) => c + i.quantity, 0);
+
+    return NextResponse.json({ ...updatedCart, items, subtotal, itemCount });
   } catch (error) {
     return apiError(error);
   }

--- a/components/cart/cart.tsx
+++ b/components/cart/cart.tsx
@@ -121,7 +121,7 @@ export function Cart({ initialCart }: CartProps) {
     )
   }
 
-  if (!cart || cart.items.length === 0) {
+  if (!cart || !cart.items || cart.items.length === 0) {
     return (
       <div className="container mx-auto px-4 py-16">
         <div className="max-w-md mx-auto text-center">


### PR DESCRIPTION
DELETE /api/cart/items/[itemId] returned only { message: ... } instead of the cart, so the Cart component's setCart() left cart.items undefined and crashed on cart.items.length when removing an item ("Cannot read properties of undefined (reading 'length')").

- DELETE now returns the full updated cart (items, subtotal, itemCount), matching PATCH and GET /api/cart
- defensively guard the empty-cart check (!cart.items) so a malformed response can never crash the render