### PR TITLE
feat(ui): interactive navigation feedback + button effects

### DIFF
--- a/app/account/loading.tsx
+++ b/app/account/loading.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+// Account transition skeleton: profile header + a stack of menu rows.
+export default function AccountLoading() {
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mb-8 flex items-center gap-4">
+        <Skeleton className="h-16 w-16 rounded-full" />
+        <div className="space-y-2">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-4 w-52" />
+        </div>
+      </div>
+      <div className="space-y-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-14 w-full rounded-lg" />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/cart/loading.tsx
+++ b/app/cart/loading.tsx
@@ -1,0 +1,32 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+// Cart transition skeleton: a list of line items on the left, order summary on
+// the right — matching the cart page's two-column layout.
+export default function CartLoading() {
+  return (
+    <div className="container mx-auto px-4 py-8 sm:px-6 lg:px-8">
+      <Skeleton className="mb-8 h-8 w-40" />
+      <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
+        <div className="space-y-4 lg:col-span-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="flex gap-4 rounded-lg border border-gray-100 p-4">
+              <Skeleton className="h-24 w-20 rounded-md" />
+              <div className="flex-1 space-y-3 py-1">
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-4 w-1/4" />
+                <Skeleton className="h-8 w-28 rounded-md" />
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="space-y-4 rounded-lg bg-gray-50 p-6">
+          <Skeleton className="h-6 w-32" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-2/3" />
+          <Skeleton className="h-12 w-full rounded-lg" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/categories/loading.tsx
+++ b/app/categories/loading.tsx
@@ -1,0 +1,12 @@
+import { ProductGridSkeleton } from '@/components/ui/skeleton'
+
+// Shown while /categories loads. The category tiles share the same 3/4 aspect
+// card shape as products, so the product grid skeleton is a faithful stand-in.
+export default function CategoriesLoading() {
+  return (
+    <div className="container mx-auto px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mb-8 h-8 w-56 animate-pulse rounded bg-gray-200" />
+      <ProductGridSkeleton count={6} />
+    </div>
+  )
+}

--- a/app/checkout/loading.tsx
+++ b/app/checkout/loading.tsx
@@ -1,0 +1,24 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+// Checkout transition skeleton: address / payment column on the left, order
+// summary on the right.
+export default function CheckoutLoading() {
+  return (
+    <div className="container mx-auto px-4 py-8 sm:px-6 lg:px-8">
+      <Skeleton className="mb-8 h-8 w-44" />
+      <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
+        <div className="space-y-4 lg:col-span-2">
+          <Skeleton className="h-32 w-full rounded-lg" />
+          <Skeleton className="h-32 w-full rounded-lg" />
+        </div>
+        <div className="space-y-4 rounded-lg border border-gray-100 p-6">
+          <Skeleton className="h-6 w-32" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-2/3" />
+          <Skeleton className="h-12 w-full rounded-full" />
+          <Skeleton className="h-12 w-full rounded-full" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -857,3 +857,67 @@ html {
   overscroll-behavior-y: contain;
 }
 
+/* ── Interactive button feedback ──────────────────────────────────────────
+   Reusable press / ripple effects shared by the <Button> component and any
+   element that opts in via these classes. Kept here (not Tailwind config) so
+   the keyframes and the ::after ripple pseudo-element live together. */
+
+/* `.btn-press` — a tactile scale-down on press plus a quick return. Pair with
+   `transition-transform` so the spring-back reads smoothly. Respects
+   prefers-reduced-motion below. */
+.btn-press {
+  transition: transform 0.12s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.btn-press:active {
+  transform: scale(0.96);
+}
+
+/* `.ripple` — a material-style ink ripple that radiates from where the user
+   pressed. The <Button> component sets the ripple origin via the
+   `--ripple-x` / `--ripple-y` custom properties on click. */
+.ripple {
+  position: relative;
+  overflow: hidden;
+}
+.ripple::after {
+  content: '';
+  position: absolute;
+  left: var(--ripple-x, 50%);
+  top: var(--ripple-y, 50%);
+  width: 0;
+  height: 0;
+  border-radius: 9999px;
+  background: currentColor;
+  opacity: 0;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+/* When the component toggles `data-rippling`, expand + fade the ink out. */
+.ripple[data-rippling='true']::after {
+  animation: rippleExpand 0.6s ease-out;
+}
+@keyframes rippleExpand {
+  0% {
+    width: 0;
+    height: 0;
+    opacity: 0.35;
+  }
+  100% {
+    width: 250%;
+    height: 250%;
+    opacity: 0;
+  }
+}
+
+/* Honour users who ask for less motion: drop the press scale and ripple. */
+@media (prefers-reduced-motion: reduce) {
+  .btn-press,
+  .btn-press:active {
+    transform: none;
+    transition: none;
+  }
+  .ripple[data-rippling='true']::after {
+    animation: none;
+  }
+}
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,9 @@
 import type { Metadata, Viewport } from 'next'
 import { Inter, Playfair_Display } from 'next/font/google'
+import { Suspense } from 'react'
 import './globals.css'
 import { Providers } from '@/components/providers'
+import { NavigationProgress } from '@/components/ui/navigation-progress'
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter' })
 
@@ -64,6 +66,12 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${inter.variable} ${playfair.variable}`}>
       <body className={inter.className}>
+        {/* Top-of-page navigation progress bar. Suspense is required because it
+            reads useSearchParams; without it Next would opt the whole tree into
+            client rendering. */}
+        <Suspense fallback={null}>
+          <NavigationProgress />
+        </Suspense>
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/app/products/[slug]/loading.tsx
+++ b/app/products/[slug]/loading.tsx
@@ -1,0 +1,31 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+// Product detail transition skeleton: mirrors the two-column layout
+// (square gallery on the left, title / price / actions on the right).
+export default function ProductDetailLoading() {
+  return (
+    <div className="container mx-auto px-4 py-4 lg:py-8">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 lg:gap-12">
+        {/* Gallery */}
+        <Skeleton className="aspect-square w-full rounded-lg" />
+
+        {/* Details */}
+        <div className="space-y-5">
+          <Skeleton className="h-7 w-3/4" />
+          <Skeleton className="h-4 w-1/3" />
+          <Skeleton className="h-9 w-1/2" />
+          <div className="space-y-2 pt-2">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
+          <div className="flex gap-3 pt-4">
+            <Skeleton className="h-12 w-12 rounded-lg" />
+            <Skeleton className="h-12 flex-1 rounded-lg" />
+          </div>
+          <Skeleton className="h-12 w-full rounded-lg" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/products/loading.tsx
+++ b/app/products/loading.tsx
@@ -1,0 +1,13 @@
+import { ProductGridSkeleton } from '@/components/ui/skeleton'
+
+// Shown the instant /products is navigated to, while the page's data loads.
+// Mirrors the products grid so the transition lands on the right shape rather
+// than a frozen previous page.
+export default function ProductsLoading() {
+  return (
+    <div className="container mx-auto px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mb-8 h-8 w-48 animate-pulse rounded bg-gray-200" />
+      <ProductGridSkeleton count={8} />
+    </div>
+  )
+}

--- a/components/home/featured-products.tsx
+++ b/components/home/featured-products.tsx
@@ -102,20 +102,21 @@ export function FeaturedProducts() {
           </div>
         ) : (
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6">
-            {products.map((product) => (
+            {products.map((product, index) => (
             <div
               key={product.id}
-              className="group relative"
+              className="group relative animate-slide-up"
+              style={{ animationDelay: `${index * 80}ms` }}
               onMouseEnter={() => setHoveredProduct(product.id)}
               onMouseLeave={() => setHoveredProduct(null)}
             >
               <Link href={`/products/${product.slug}`}>
-                <div className="relative aspect-[3/4] mb-3 overflow-hidden rounded-lg bg-gray-100">
+                <div className="relative aspect-[3/4] mb-3 overflow-hidden rounded-lg bg-gray-100 transition-shadow duration-300 group-hover:shadow-xl">
                   <Image
                     src={product.image}
                     alt={product.name}
                     fill
-                    className="object-cover group-hover:scale-105 transition-transform duration-300"
+                    className="object-cover group-hover:scale-110 transition-transform duration-500 ease-out"
                   />
                   {product.isNew && (
                     <span className="absolute top-2 left-2 z-10 bg-primary text-white text-xs px-2 py-1 rounded">
@@ -140,7 +141,7 @@ export function FeaturedProducts() {
                       ? 'opacity-100 translate-y-0'
                       : 'opacity-0 translate-y-4'
                   }`}>
-                    <button className="bg-white p-2 rounded-full shadow-lg hover:bg-gray-100 transition-colors">
+                    <button className="btn-press bg-white p-2 rounded-full shadow-lg hover:bg-gray-100 hover:scale-110 transition-all">
                       <ShoppingCart size={18} className="text-gray-700" />
                     </button>
                   </div>
@@ -185,7 +186,7 @@ export function FeaturedProducts() {
 
               <button
                 onClick={() => toggleWishlist(product.id)}
-                className={`absolute top-2 right-2 p-2 rounded-full transition-all ${
+                className={`btn-press absolute top-2 right-2 p-2 rounded-full transition-all hover:scale-110 active:scale-90 ${
                   wishlist.includes(product.id)
                     ? 'bg-red-500 text-white'
                     : 'bg-white/80 text-gray-700 hover:bg-white'

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { forwardRef, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+/**
+ * Button — the shared, interactive button for the storefront.
+ *
+ * What it gives every button for free:
+ *  - a tactile press (scale-down on click) via `.btn-press`
+ *  - a material-style ink ripple radiating from the click point via `.ripple`
+ *  - a built-in `loading` state: shows a spinner, swaps the label for
+ *    `loadingText` (if given), and disables interaction
+ *
+ * Variants intentionally mirror the existing `.btn-*` utilities and the app's
+ * saree palette so adoption is a drop-in. Built on a native <button>, so all
+ * standard button props (type, onClick, aria-*, etc.) pass straight through.
+ */
+
+type Variant = 'primary' | 'secondary' | 'ghost' | 'maroon' | 'outline'
+type Size = 'sm' | 'md' | 'lg'
+
+const VARIANT_CLASSES: Record<Variant, string> = {
+  // Dark, high-emphasis — the app's default primary action.
+  primary:
+    'bg-gray-900 text-white hover:bg-gray-800 hover:shadow-lg disabled:hover:bg-gray-900',
+  // Light, bordered — secondary actions.
+  secondary:
+    'bg-white text-gray-900 border border-gray-300 hover:bg-gray-50 hover:shadow-md',
+  // Transparent — tertiary / inline actions.
+  ghost: 'text-gray-600 hover:text-gray-900 hover:bg-gray-100/50',
+  // Saree-palette maroon — used for branded calls to action (auth, etc.).
+  maroon:
+    'bg-gradient-to-r from-maroon-700 to-maroon-600 text-marigold-50 shadow-lg shadow-maroon-900/20 hover:from-maroon-800 hover:to-maroon-700 hover:shadow-xl',
+  // Bordered red outline — e.g. "buy" alternatives.
+  outline:
+    'bg-transparent text-primary-600 border border-primary-600 hover:bg-primary-50',
+}
+
+const SIZE_CLASSES: Record<Size, string> = {
+  sm: 'px-3 py-2 text-sm gap-1.5',
+  md: 'px-5 py-2.5 text-sm gap-2',
+  lg: 'px-6 py-3 text-base gap-2',
+}
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: Variant
+  size?: Size
+  loading?: boolean
+  /** Replaces the children while `loading` is true (e.g. "Adding…"). */
+  loadingText?: React.ReactNode
+  /** Optional leading icon (hidden while loading — the spinner takes its place). */
+  leftIcon?: React.ReactNode
+  /** Stretch to the full width of the parent. */
+  fullWidth?: boolean
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      variant = 'primary',
+      size = 'md',
+      loading = false,
+      loadingText,
+      leftIcon,
+      fullWidth = false,
+      className,
+      children,
+      disabled,
+      onClick,
+      ...props
+    },
+    ref
+  ) => {
+    // Drives the `data-rippling` attribute that triggers the CSS ripple animation.
+    const [rippling, setRippling] = useState(false)
+
+    const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+      if (loading || disabled) return
+
+      // Position the ripple origin at the click point (relative to the button).
+      const rect = e.currentTarget.getBoundingClientRect()
+      const x = e.clientX - rect.left
+      const y = e.clientY - rect.top
+      e.currentTarget.style.setProperty('--ripple-x', `${x}px`)
+      e.currentTarget.style.setProperty('--ripple-y', `${y}px`)
+
+      // Re-trigger the animation even on rapid repeated clicks.
+      setRippling(false)
+      requestAnimationFrame(() => setRippling(true))
+
+      onClick?.(e)
+    }
+
+    return (
+      <button
+        ref={ref}
+        onClick={handleClick}
+        onAnimationEnd={() => setRippling(false)}
+        data-rippling={rippling ? 'true' : 'false'}
+        disabled={disabled || loading}
+        aria-busy={loading || undefined}
+        className={cn(
+          // base
+          'btn-press ripple relative inline-flex items-center justify-center rounded-full font-medium tracking-wide',
+          'transition-all duration-200',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-900/40',
+          'disabled:cursor-not-allowed disabled:opacity-60',
+          VARIANT_CLASSES[variant],
+          SIZE_CLASSES[size],
+          fullWidth && 'w-full',
+          className
+        )}
+        {...props}
+      >
+        {loading ? (
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+        ) : (
+          leftIcon
+        )}
+        <span>{loading && loadingText ? loadingText : children}</span>
+      </button>
+    )
+  }
+)
+
+Button.displayName = 'Button'

--- a/components/ui/navigation-progress.tsx
+++ b/components/ui/navigation-progress.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { usePathname, useSearchParams } from 'next/navigation'
+
+/**
+ * NavigationProgress — a YouTube/GitHub-style sliver bar that pins to the top of
+ * the viewport the instant a user clicks an in-app link, and completes once the
+ * new route has painted.
+ *
+ * Why this exists: Next.js App Router keeps the *current* page fully visible
+ * while it streams the next route's server data. With no feedback, a click reads
+ * as "frozen" for a second or two. This bar makes navigation feel instant even
+ * when the network isn't.
+ *
+ * How it works:
+ *  - We can't hook Next's router transition directly in a stable way, so we
+ *    listen for clicks on anchor (<a>) elements that point at same-origin routes
+ *    and start the bar immediately on click (zero perceived latency).
+ *  - When `pathname` / `searchParams` actually change, the route has committed,
+ *    so we snap the bar to 100% and fade it out.
+ */
+export function NavigationProgress() {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  // `progress` is 0–100; `visible` controls mount/fade of the bar.
+  const [progress, setProgress] = useState(0)
+  const [visible, setVisible] = useState(false)
+
+  // Timers we need to clear so a fast second navigation doesn't fight the first.
+  const trickleRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const doneRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearTimers = () => {
+    if (trickleRef.current) clearInterval(trickleRef.current)
+    if (doneRef.current) clearTimeout(doneRef.current)
+    trickleRef.current = null
+    doneRef.current = null
+  }
+
+  // Kick the bar off and let it "trickle" toward ~85% — it never reaches 100%
+  // on its own; the route change (effect below) is what finishes it.
+  const start = () => {
+    clearTimers()
+    setVisible(true)
+    setProgress(12)
+    trickleRef.current = setInterval(() => {
+      setProgress((p) => {
+        if (p >= 85) return p
+        // Decelerate as we climb so it feels like real loading, not a metronome.
+        const remaining = 85 - p
+        return p + Math.max(1, remaining * 0.12)
+      })
+    }, 220)
+  }
+
+  // Finish: snap to 100%, then fade out and reset.
+  const done = () => {
+    clearTimers()
+    setProgress(100)
+    doneRef.current = setTimeout(() => {
+      setVisible(false)
+      // Reset to 0 only after the fade-out has played (300ms transition below).
+      setTimeout(() => setProgress(0), 300)
+    }, 250)
+  }
+
+  // Intercept same-origin link clicks to start the bar at click time.
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      // Respect modified clicks (new tab/window) and non-primary buttons.
+      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+        return
+      }
+      const anchor = (e.target as HTMLElement)?.closest('a')
+      if (!anchor) return
+
+      const href = anchor.getAttribute('href')
+      const target = anchor.getAttribute('target')
+      if (!href || target === '_blank' || anchor.hasAttribute('download')) return
+
+      // Only same-origin, real navigations. Skip hash-only and external links.
+      let url: URL
+      try {
+        url = new URL(href, window.location.href)
+      } catch {
+        return
+      }
+      if (url.origin !== window.location.origin) return
+      const samePage = url.pathname === window.location.pathname && url.search === window.location.search
+      if (samePage) return // hash jump or no-op — don't flash the bar
+
+      start()
+    }
+
+    document.addEventListener('click', onClick, { capture: true })
+    return () => document.removeEventListener('click', onClick, { capture: true })
+    // start/done are stable for our purposes; we intentionally bind once.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // When the route actually changes, the navigation has committed — finish.
+  useEffect(() => {
+    if (!visible) return
+    done()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname, searchParams])
+
+  // Clean up on unmount.
+  useEffect(() => () => clearTimers(), [])
+
+  if (!visible && progress === 0) return null
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-x-0 top-0 z-[9999] h-[3px]"
+    >
+      <div
+        className="h-full bg-gradient-to-r from-maroon-600 via-primary-600 to-marigold-400 shadow-[0_0_8px_rgba(0,0,0,0.25)] transition-[width,opacity] duration-300 ease-out"
+        style={{
+          width: `${progress}%`,
+          opacity: visible ? 1 : 0,
+        }}
+      />
+    </div>
+  )
+}

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,52 @@
+import { cn } from '@/lib/utils'
+
+/**
+ * Skeleton — a single shimmering placeholder block. Compose these to mimic the
+ * shape of content while it loads. Uses the `shimmer` utility (defined in
+ * globals.css) for a left-to-right sheen rather than a flat pulse, which reads
+ * as "loading" more clearly on a premium storefront.
+ */
+export function Skeleton({ className }: { className?: string }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        'relative overflow-hidden rounded-md bg-gray-200/80',
+        'before:absolute before:inset-0 before:-translate-x-full',
+        'before:animate-[shimmer_1.6s_infinite]',
+        'before:bg-gradient-to-r before:from-transparent before:via-white/60 before:to-transparent',
+        className
+      )}
+    />
+  )
+}
+
+/**
+ * ProductCardSkeleton — matches the shape of a product card in the grid
+ * (image + title + rating + price), so route transitions land on a layout that
+ * mirrors the real content instead of a blank screen.
+ */
+export function ProductCardSkeleton() {
+  return (
+    <div className="space-y-3">
+      <Skeleton className="aspect-[3/4] w-full rounded-lg" />
+      <Skeleton className="h-4 w-4/5" />
+      <Skeleton className="h-3 w-1/3" />
+      <Skeleton className="h-4 w-1/2" />
+    </div>
+  )
+}
+
+/**
+ * ProductGridSkeleton — a full grid of card skeletons. `count` defaults to 8,
+ * matching a typical first paint of the products / category pages.
+ */
+export function ProductGridSkeleton({ count = 8 }: { count?: number }) {
+  return (
+    <div className="grid grid-cols-2 gap-4 sm:gap-6 lg:grid-cols-4">
+      {Array.from({ length: count }).map((_, i) => (
+        <ProductCardSkeleton key={i} />
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
Eliminate the "stale page" feel on navigation and make buttons feel tactile and responsive.

- NavigationProgress: top-of-page progress bar that starts on link click and completes on route commit (wired into root layout via Suspense)
- loading.tsx skeletons for products, product detail, categories, cart, checkout, and account routes so transitions land on the right shape
- Skeleton primitive + ProductCard/ProductGrid skeletons (shimmer sheen)
- Shared <Button> component: material ripple from click point, press scale, 5 palette variants, built-in loading spinner + disable
- .btn-press / .ripple CSS utilities (respect prefers-reduced-motion)
- Featured products: deeper image zoom, hover shadow, staggered slide-up entrance, btn-press on cart/wishlist buttons